### PR TITLE
feat: cargo workspace + scribe binary skeleton

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,26 @@
+[workspace]
+resolver = "2"
+members = [
+    "crates/scribe",
+]
+
+[workspace.package]
+edition = "2021"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/raibid-labs/scribe"
+authors = ["raibid-labs"]
+
+[workspace.dependencies]
+# CLI parsing
+clap = { version = "4.5", features = ["derive"] }
+
+# Error handling
+anyhow = "1.0"
+
+# Serialization
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+# Logging
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/scribe/Cargo.toml
+++ b/crates/scribe/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "scribe"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Verbatim audio-to-Markdown transcription CLI built on whisper.cpp and ffmpeg"
+
+[[bin]]
+name = "scribe"
+path = "src/main.rs"
+
+[dependencies]
+clap.workspace = true
+anyhow.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true

--- a/crates/scribe/README.md
+++ b/crates/scribe/README.md
@@ -1,0 +1,9 @@
+# scribe
+
+The `scribe` binary crate is the user-facing CLI for the [Scribe](../../README.md)
+verbatim audio-to-Markdown transcription utility. It hosts the top-level
+`scribe transcribe` and `scribe doctor` commands; the pipeline itself
+(ffmpeg + whisper.cpp subprocess invocations, dual Markdown + JSON output)
+lands in subsequent issues. See the [top-level README](../../README.md)
+and [`docs/01-architecture.md`](../../docs/01-architecture.md) for design
+rationale.

--- a/crates/scribe/src/main.rs
+++ b/crates/scribe/src/main.rs
@@ -1,0 +1,76 @@
+//! Scribe CLI entry point.
+//!
+//! This is the v0.1 skeleton: clap-derived top-level CLI with `transcribe`
+//! and `doctor` subcommands. Both subcommands are stubs that print
+//! "not implemented" and exit 0. The real pipeline lands in issues #5
+//! (`doctor`) and #6 (`transcribe`).
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+use tracing_subscriber::EnvFilter;
+
+/// Verbatim audio-to-Markdown transcription CLI.
+///
+/// Takes an audio file, runs it through ffmpeg + whisper.cpp, and emits
+/// a verbatim Markdown transcript plus a timestamped JSON sidecar.
+#[derive(Debug, Parser)]
+#[command(name = "scribe", version, about, long_about = None)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// Transcribe an audio file to Markdown + JSON.
+    Transcribe(TranscribeArgs),
+
+    /// Verify ffmpeg, whisper-cli, and model availability.
+    Doctor,
+}
+
+#[derive(Debug, clap::Args)]
+struct TranscribeArgs {
+    /// Input audio file (mp3, m4a, wav, mp4, ...).
+    #[arg(long, value_name = "FILE")]
+    input: PathBuf,
+
+    /// Output directory for the .md and .json files.
+    #[arg(long, value_name = "DIR")]
+    out_dir: PathBuf,
+
+    /// Optional whisper.cpp model name (e.g. `large-v3`).
+    #[arg(long, value_name = "NAME")]
+    model: Option<String>,
+}
+
+fn main() -> Result<()> {
+    init_tracing();
+
+    let cli = Cli::parse();
+
+    match cli.command {
+        Command::Transcribe(args) => run_transcribe(args),
+        Command::Doctor => run_doctor(),
+    }
+}
+
+fn init_tracing() {
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_target(false)
+        .init();
+}
+
+fn run_transcribe(_args: TranscribeArgs) -> Result<()> {
+    println!("scribe transcribe: not implemented");
+    Ok(())
+}
+
+fn run_doctor() -> Result<()> {
+    println!("scribe doctor: not implemented");
+    Ok(())
+}

--- a/crates/scribe/tests/cli.rs
+++ b/crates/scribe/tests/cli.rs
@@ -1,0 +1,39 @@
+//! Smoke tests for the `scribe` binary.
+
+use std::process::Command;
+
+/// Path to the compiled `scribe` binary, provided by Cargo for integration tests.
+const SCRIBE_BIN: &str = env!("CARGO_BIN_EXE_scribe");
+
+#[test]
+fn help_exits_zero() {
+    let status = Command::new(SCRIBE_BIN)
+        .arg("--help")
+        .status()
+        .expect("failed to invoke scribe --help");
+    assert!(status.success(), "scribe --help exited with {status:?}");
+}
+
+#[test]
+fn transcribe_help_exits_zero() {
+    let status = Command::new(SCRIBE_BIN)
+        .args(["transcribe", "--help"])
+        .status()
+        .expect("failed to invoke scribe transcribe --help");
+    assert!(
+        status.success(),
+        "scribe transcribe --help exited with {status:?}"
+    );
+}
+
+#[test]
+fn doctor_help_exits_zero() {
+    let status = Command::new(SCRIBE_BIN)
+        .args(["doctor", "--help"])
+        .status()
+        .expect("failed to invoke scribe doctor --help");
+    assert!(
+        status.success(),
+        "scribe doctor --help exited with {status:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Lands the foundational Cargo workspace + `crates/scribe/` binary crate skeleton that the rest of the v0.1 work plan builds on.

- Top-level `Cargo.toml` workspace (`resolver = "2"`) with shared `[workspace.package]` metadata (`edition = "2021"`, `license = "MIT OR Apache-2.0"`, `repository`, `authors`) and `[workspace.dependencies]` for clap, anyhow, serde, serde_json, tracing, tracing-subscriber.
- `crates/scribe/` binary crate inheriting workspace metadata, with a clap-derived top-level CLI exposing two subcommands:
  - `scribe transcribe --input <FILE> --out-dir <DIR> [--model <NAME>]`
  - `scribe doctor`
  Both are stubs that print "not implemented" and exit 0. Real pipeline lands in #5 (doctor) and #6 (transcribe).
- Smoke tests under `crates/scribe/tests/cli.rs` asserting `--help`, `transcribe --help`, and `doctor --help` all exit 0 via `CARGO_BIN_EXE_scribe`.
- One-paragraph `crates/scribe/README.md` pointing back to the top-level docs.

Closes #1.

## Files added

- `Cargo.toml`
- `crates/scribe/Cargo.toml`
- `crates/scribe/README.md`
- `crates/scribe/src/main.rs`
- `crates/scribe/tests/cli.rs`

## Green-light status

- `cargo build` — clean
- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean (no allow overrides)
- `cargo test --all` — 3/3 smoke tests pass

## Out of scope (per issue)

- ffmpeg + whisper-cli subprocess integration (#6)
- Doctor implementation (#5)
- Justfile (#2), CI (#3), release pipeline (#4)
- Integration tests against real audio (#7)

## Test plan

- [ ] `cargo build` succeeds
- [ ] `cargo fmt --all -- --check` clean
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [ ] `cargo test --all` passes
- [ ] `cargo run -- transcribe --input foo.mp3 --out-dir /tmp` prints "scribe transcribe: not implemented" and exits 0
- [ ] `cargo run -- doctor` prints "scribe doctor: not implemented" and exits 0

Generated with Claude Code.