### PR TITLE
docs: expand docs/ with CLI reference, contributing, troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ scribe transcribe --input podcast.mp3 --out-dir ~/transcripts
 - [`docs/03-related-tools.md`](./docs/03-related-tools.md) — how Scribe fits
   with other raibid-labs projects (Scryforge, voice-stuff, Phage, gudpkm
   n8n)
+- [`docs/04-cli-reference.md`](./docs/04-cli-reference.md) — subcommands,
+  flags, env vars, exit codes, output layout
+- [`docs/05-contributing.md`](./docs/05-contributing.md) — dev environment
+  setup, code style, PR conventions, how to extend inputs and outputs
+- [`docs/06-troubleshooting.md`](./docs/06-troubleshooting.md) — common
+  failure modes and fixes
 
 ## Related raibid-labs projects
 

--- a/docs/00-index.md
+++ b/docs/00-index.md
@@ -13,6 +13,14 @@ This directory holds Scribe's design and reference docs.
 - [`03-related-tools.md`](./03-related-tools.md) — how Scribe fits with
   Scryforge, voice-stuff, the gudpkm n8n flow, the future Murmur dictation
   utility, and Phage
+- [`04-cli-reference.md`](./04-cli-reference.md) — every subcommand and
+  flag, env vars, exit codes, output layout
+- [`05-contributing.md`](./05-contributing.md) — dev environment setup
+  (rustup, just, ffmpeg, whisper.cpp, models), code style, PR
+  conventions, how to extend inputs and outputs
+- [`06-troubleshooting.md`](./06-troubleshooting.md) — common failure
+  modes (missing ffmpeg / whisper-cli / model, CUDA absence, whisper
+  hallucinations on silence)
 
 ## Pointers
 

--- a/docs/04-cli-reference.md
+++ b/docs/04-cli-reference.md
@@ -1,0 +1,136 @@
+# CLI reference
+
+> This is the intended CLI surface; implementation tracks issues
+> [#5](https://github.com/raibid-labs/scribe/issues/5) and
+> [#6](https://github.com/raibid-labs/scribe/issues/6).
+
+Scribe is a single binary with subcommands. The top-level shape:
+
+```
+scribe <SUBCOMMAND> [FLAGS]
+```
+
+Subcommands:
+
+- [`transcribe`](#scribe-transcribe) — run the audio → markdown + JSON
+  pipeline
+- [`doctor`](#scribe-doctor) — verify ffmpeg, whisper-cli, and a usable
+  model are installed
+
+## `scribe transcribe`
+
+Resample an audio or video file with ffmpeg, run it through whisper.cpp,
+and write a markdown transcript plus a JSON sidecar to `--out-dir`.
+
+```
+scribe transcribe --input <FILE> --out-dir <DIR> [--model <NAME>] [--keep-temp]
+```
+
+### Flags
+
+| Flag | Required | Description |
+| --- | --- | --- |
+| `--input <FILE>` | yes | Path to an audio or video file. Any format ffmpeg can read. |
+| `--out-dir <DIR>` | yes | Directory for the `.md` and `.json` outputs. Created if missing. |
+| `--model <NAME>` | no | Whisper model name. Resolved against `$SCRIBE_MODEL_PATH` (or the default model dir). Defaults to `$SCRIBE_MODEL` if set, else a built-in default (`large-v3` if available, else `base.en`). |
+| `--keep-temp` | no | Do not delete the intermediate 16 kHz WAV. Useful for debugging. |
+
+### Environment variables
+
+- `SCRIBE_MODEL` — default model name when `--model` is not passed.
+- `SCRIBE_MODEL_PATH` — directory to resolve model names against.
+- `SCRIBE_WHISPER_BIN` — path to the `whisper-cli` binary. Falls back to
+  `~/raibid-labs/voice-stuff/third_party/whisper.cpp/build/bin/whisper-cli`.
+
+### Output
+
+For an input named `My Podcast Ep 42.mp3` transcribed at
+`2026-04-28T14:30:00Z`, with `--out-dir ~/transcripts`:
+
+```
+~/transcripts/my-podcast-ep-42-20260428-143000.md
+~/transcripts/my-podcast-ep-42-20260428-143000.json
+```
+
+The slug is the input filename stem, lowercased, with non-alphanumerics
+collapsed to `-`. The timestamp is `YYYYMMDD-HHMMSS` in UTC.
+
+The markdown wraps the verbatim whisper output in YAML frontmatter:
+
+```yaml
+---
+type: transcript
+source: /abs/path/to/My Podcast Ep 42.mp3
+title: My Podcast Ep 42
+created: 2026-04-28T14:30:00Z
+duration_sec: 3127.4
+model: large-v3
+sidecar: my-podcast-ep-42-20260428-143000.json
+tags: [type/transcript]
+---
+```
+
+The JSON sidecar is whisper.cpp's segment-level output, untouched.
+
+### Examples
+
+Basic:
+
+```sh
+scribe transcribe --input podcast.mp3 --out-dir ~/transcripts
+```
+
+With an explicit model:
+
+```sh
+scribe transcribe \
+  --input lecture.m4a \
+  --out-dir ~/transcripts/lectures \
+  --model base.en
+```
+
+Keep the temp WAV for debugging:
+
+```sh
+scribe transcribe --input voice-memo.m4a --out-dir . --keep-temp
+```
+
+### Exit codes
+
+- `0` — markdown + JSON written.
+- non-zero — any pipeline step failed; an error is printed to stderr.
+
+## `scribe doctor`
+
+Verify the runtime dependencies. Prints a status line for each.
+
+```
+scribe doctor
+```
+
+### Checks
+
+- `ffmpeg` — resolves with `which ffmpeg`, prints the first line of
+  `ffmpeg -version`.
+- `whisper-cli` — checks `$SCRIBE_WHISPER_BIN`, then a sensible default
+  (`~/raibid-labs/voice-stuff/third_party/whisper.cpp/build/bin/whisper-cli`).
+  Prints version if available.
+- `model` — checks `$SCRIBE_MODEL_PATH`, then a default model dir
+  (`~/raibid-labs/voice-stuff/models/`). Lists any `.bin` files found.
+- `GPU` — runs `nvidia-smi --query-gpu=name --format=csv,noheader` if
+  available; prints `n/a` otherwise. Non-fatal — CPU-only is acceptable.
+
+### Exit codes
+
+- `0` — all checks pass, or only the GPU check is missing.
+- `1` — ffmpeg, whisper-cli, or model is missing.
+
+### Example
+
+```sh
+$ scribe doctor
+ffmpeg       /usr/bin/ffmpeg            ffmpeg version 6.1.1
+whisper-cli  ~/raibid-labs/.../whisper-cli  whisper.cpp v1.7.x
+model        ~/raibid-labs/voice-stuff/models  ggml-large-v3.bin, ggml-base.en.bin
+GPU          NVIDIA GB10
+```

--- a/docs/05-contributing.md
+++ b/docs/05-contributing.md
@@ -1,0 +1,149 @@
+# Contributing
+
+Dev environment setup and contribution conventions for Scribe.
+
+## Prerequisites
+
+Scribe is a Rust CLI that shells out to `ffmpeg` and `whisper-cli`. You
+need all three on your `PATH` (or pointed at via env vars — see
+[`04-cli-reference.md`](./04-cli-reference.md)).
+
+### Rust
+
+Install via [rustup](https://rustup.rs/):
+
+```sh
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+The workspace targets the **stable** toolchain, edition 2021. A
+`rust-toolchain.toml` may pin a specific stable release once issue
+[#1](https://github.com/raibid-labs/scribe/issues/1) lands; until then,
+current stable is fine.
+
+### just
+
+`just` runs the project's task recipes. Install:
+
+```sh
+cargo install just
+```
+
+The `justfile` is tracked under issue
+[#2](https://github.com/raibid-labs/scribe/issues/2) (pending — recipes
+do not exist yet). The intended recipe set:
+
+- `just build` — `cargo build --all`
+- `just test` — `cargo test --all`
+- `just fmt` — `cargo fmt --all`
+- `just fmt-check` — `cargo fmt --all -- --check`
+- `just lint` — `cargo clippy --all-targets --all-features -- -D warnings`
+- `just check` — `cargo check --all`
+- `just run *args` — `cargo run -p scribe -- {{args}}`
+- `just doctor` — `cargo run -p scribe -- doctor`
+- `just install` — `cargo install --path crates/scribe`
+- `just clean` — `cargo clean`
+
+Until #2 merges, run the underlying `cargo` commands directly.
+
+### ffmpeg
+
+Debian / Ubuntu:
+
+```sh
+sudo apt install ffmpeg
+```
+
+macOS:
+
+```sh
+brew install ffmpeg
+```
+
+### whisper.cpp
+
+Scribe expects a working `whisper-cli` binary on `PATH` or pointed at via
+`$SCRIBE_WHISPER_BIN`. The simplest path is to follow the build
+instructions in `~/raibid-labs/voice-stuff/docs/setup.md` — that repo's
+build (CUDA-enabled, against a known-good whisper.cpp commit) is the
+canonical engine for the raibid-labs stack.
+
+Until voice-stuff is published to GitHub, those local instructions are
+the canonical reference.
+
+### Models
+
+Whisper model files (`.bin`) are also managed by voice-stuff. Use its
+`just fetch-model <name>` recipe to download a specific model:
+
+```sh
+cd ~/raibid-labs/voice-stuff
+just fetch-model large-v3
+```
+
+Models land in `~/raibid-labs/voice-stuff/models/`. Point Scribe at them
+via `$SCRIBE_MODEL_PATH` (or rely on the default).
+
+## Building and testing
+
+```sh
+cargo build --all
+cargo test --all
+```
+
+## Code style
+
+Required before pushing:
+
+```sh
+cargo fmt --all
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+Clippy must be clean — CI enforces `-D warnings`.
+
+## PR conventions
+
+- Branch from `main`. One issue per branch where possible.
+- Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/):
+  `feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `test:`, `ci:`.
+- Reference the issue in the PR body (`Closes #N`).
+- Do **not** merge your own PR. Hand off to a reviewer.
+- Each issue's `Rules of engagement` block names the branch
+  (`feat/<thing>`, `docs/<thing>`, etc.) and the base branch (`main`).
+  Follow it.
+
+## Adding a new input adapter
+
+Targeted at v0.2 — see [`02-roadmap.md`](./02-roadmap.md).
+
+The pipeline downstream of ffmpeg is fixed. A new input adapter's job is
+to land an audio (or audio-bearing) file at a path ffmpeg can read.
+Shape:
+
+1. Add a variant or matcher to the input-resolution layer (`config.rs` /
+   a future `input.rs`) that recognizes the new source kind.
+2. Implement a fetch step that produces a local file path. For URLs, a
+   plain HTTP GET to a temp file. For YouTube, shell out to `yt-dlp`.
+   For RSS, parse the feed and fetch the enclosure URL.
+3. Hand the resulting path to the existing pipeline. Do not reinvent the
+   ffmpeg / whisper steps.
+4. Add an integration test against a small fixture for the new input
+   kind.
+
+## Adding a new output format
+
+Targeted at v0.3 — see [`02-roadmap.md`](./02-roadmap.md).
+
+The JSON sidecar is the source of truth for any timestamped format. For
+plain text or alternative markdown shapes, derive from the verbatim text
+body. Shape:
+
+1. Add a `--format <NAME>` flag (or a `--out-format` repeat flag) on
+   `transcribe`.
+2. Implement the format writer in a new module under `output/` (e.g.
+   `output/srt.rs`, `output/vtt.rs`). Read from the JSON segments, not
+   from the markdown.
+3. Preserve the verbatim contract — the new format must reflect the
+   words whisper.cpp emitted, with no rewriting.
+4. Document the format in [`04-cli-reference.md`](./04-cli-reference.md).

--- a/docs/06-troubleshooting.md
+++ b/docs/06-troubleshooting.md
@@ -1,0 +1,110 @@
+# Troubleshooting
+
+Common failure modes and their fixes. Run [`scribe doctor`](./04-cli-reference.md#scribe-doctor)
+first — it reports most of these directly.
+
+## `ffmpeg: command not found`
+
+ffmpeg is not on `PATH`. Install it.
+
+Debian / Ubuntu:
+
+```sh
+sudo apt install ffmpeg
+```
+
+macOS:
+
+```sh
+brew install ffmpeg
+```
+
+Verify:
+
+```sh
+which ffmpeg
+ffmpeg -version
+```
+
+## `whisper-cli: not found`
+
+Scribe could not locate the `whisper-cli` binary. Two fixes:
+
+1. Set `SCRIBE_WHISPER_BIN` to the absolute path:
+
+   ```sh
+   export SCRIBE_WHISPER_BIN=/path/to/whisper-cli
+   ```
+
+2. Build whisper.cpp via the voice-stuff repo. Until voice-stuff is on
+   GitHub, the canonical build instructions live in
+   `~/raibid-labs/voice-stuff/docs/setup.md`. The resulting binary
+   lands at:
+
+   ```
+   ~/raibid-labs/voice-stuff/third_party/whisper.cpp/build/bin/whisper-cli
+   ```
+
+   That is Scribe's default lookup path — no env var needed if the
+   binary is there.
+
+## `model file not found`
+
+Scribe could not find a usable `.bin` model file. Two fixes:
+
+1. Fetch the model via voice-stuff's recipe:
+
+   ```sh
+   cd ~/raibid-labs/voice-stuff
+   just fetch-model large-v3
+   ```
+
+   Models land in `~/raibid-labs/voice-stuff/models/`, which is Scribe's
+   default model dir.
+
+2. Point Scribe at a different model dir:
+
+   ```sh
+   export SCRIBE_MODEL_PATH=/path/to/your/models
+   ```
+
+   Verify with `scribe doctor` — it lists every `.bin` it finds.
+
+## `CUDA unavailable` / GPU not detected
+
+The `GPU` line in `scribe doctor` reports `n/a` or fails.
+
+- **macOS:** expected. There is no CUDA on macOS. The `whisper-cli`
+  binary will fall back to CPU. CPU mode is acceptable for short clips
+  but slow for podcast-length audio.
+- **Linux:** check the NVIDIA driver:
+
+  ```sh
+  nvidia-smi
+  ```
+
+  If `nvidia-smi` works but `whisper-cli` still runs on CPU, the
+  whisper.cpp build was not compiled with CUDA support. Rebuild it via
+  the voice-stuff instructions.
+
+GPU absence is non-fatal — `scribe doctor` exits 0 even when only the
+GPU check fails. The transcription will still run, just slower.
+
+## "thanks for watching" / "♪" appears in transcripts
+
+Not a bug. Whisper occasionally hallucinates filler text on long
+silences — most often "thanks for watching", musical-note glyphs, or a
+loop of the last spoken phrase. See
+[`01-architecture.md`](./01-architecture.md#verbatim-only).
+
+Per the verbatim contract, **Scribe does not filter these**. The
+markdown contains exactly the text whisper.cpp emitted. Downstream
+tooling — annotation scripts, scryforge actions, ad-hoc `sed` — is the
+right place to clean them.
+
+If they are dense enough to be a problem, consider:
+
+- A different model (`large-v3` hallucinates less than `base.en`).
+- Pre-trimming long silences with ffmpeg's `silenceremove` filter
+  before transcription.
+- Post-filtering the JSON sidecar in your downstream tool.


### PR DESCRIPTION
## Summary

Expands `docs/` with three new files and updates the index + README to point at them. Independent of the source-code work; touches only `docs/` and `README.md`.

- `docs/04-cli-reference.md` — intended CLI surface for `transcribe` and `doctor`. Top-of-file note clarifies the implementation tracks issues #5 and #6. No flags invented beyond those specs.
- `docs/05-contributing.md` — rustup, `just` (with note that issue #2 is pending), ffmpeg, whisper.cpp build pointer at voice-stuff, `just fetch-model`, `cargo test --all`, fmt + clippy gates, PR conventions, forward-looking sections for v0.2 input adapters and v0.3 output formats.
- `docs/06-troubleshooting.md` — ffmpeg / whisper-cli / model not found, CUDA absence (macOS expected, Linux check `nvidia-smi`), and the whisper-on-silence hallucination footnote (Scribe does not filter; downstream tools can).
- `docs/00-index.md` and `README.md` — Documents / Documentation lists now reference all three new files.

Tone matches existing docs — short sentences, code blocks, no marketing.

Closes #8

## Test plan

- [ ] Render the three new docs on GitHub; verify the YAML / shell code blocks look right.
- [ ] Verify the index and README links resolve.
- [ ] Confirm no flags appear in `04-cli-reference.md` that are not in the issue #1 / #5 / #6 specs.

Generated with [Claude Code](https://claude.com/claude-code).