### PR TITLE
ci: fmt + clippy + test workflow on ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,91 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  fmt:
+    name: Format Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+  clippy:
+    name: Clippy Lints
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo index
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo build
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-clippy-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Run clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo index
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo build
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-test-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Run tests
+        run: cargo test --all


### PR DESCRIPTION
## Summary

Adds `.github/workflows/ci.yml` with three jobs on `ubuntu-latest`:

- `fmt` — `cargo fmt --all -- --check`
- `clippy` — `cargo clippy --all-targets --all-features -- -D warnings`, with cargo registry/git/build caches via `actions/cache@v4`
- `test` — `cargo test --all`, with the same caches

Triggers on `push` to `main` and `pull_request` to `main`. Toolchain installed via `dtolnay/rust-toolchain@stable`. Env: `CARGO_TERM_COLOR=always`, `RUST_BACKTRACE=1`. Checkout via `actions/checkout@v4`.

Linux-only per `docs/01-architecture.md` — runtime target is aarch64 Linux + CUDA; no Windows/macOS matrix in day-to-day CI. Release-binary concerns belong to #4.

## Validation

All three commands run green locally against the workspace at HEAD:

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all` (4 tests pass across the workspace)

Closes #3.

## Test plan

- [ ] Workflow appears in the Actions tab on push.
- [ ] All three jobs (`fmt`, `clippy`, `test`) succeed on this PR.
- [ ] Cache restore step reports a hit on a follow-up run.

[Generated with Claude Code](https://claude.com/claude-code)