### PR TITLE
chore: justfile with standard recipes

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,66 @@
+# Scribe
+# Justfile for common development tasks.
+
+# Default recipe: list available recipes
+default:
+    @just --list
+
+# --- Build ---
+
+# Build all crates (debug)
+build:
+    cargo build --all
+
+# Build all crates with release optimizations
+build-release:
+    cargo build --release --all
+
+# --- Test & checks ---
+
+# Run all tests
+test:
+    cargo test --all
+
+# Type-check the workspace without producing artifacts
+check:
+    cargo check --all
+
+# --- Formatting & lint ---
+
+# Format all code with rustfmt
+fmt:
+    cargo fmt --all
+
+# Verify formatting without modifying files
+fmt-check:
+    cargo fmt --all -- --check
+
+# Run clippy with warnings denied
+lint:
+    cargo clippy --all-targets --all-features -- -D warnings
+
+# --- Run ---
+
+# Run the scribe binary with arbitrary args
+run *args:
+    cargo run -p scribe -- {{args}}
+
+# Run scribe's `doctor` subcommand
+doctor:
+    cargo run -p scribe -- doctor
+
+# --- Install & housekeeping ---
+
+# Install the scribe binary to ~/.cargo/bin
+install:
+    cargo install --path crates/scribe
+
+# Remove the target/ directory
+clean:
+    cargo clean
+
+# --- Release ---
+
+# Placeholder release dry-run; tracked in #4
+release-dry-run:
+    @echo "see #4"


### PR DESCRIPTION
## Summary

Adds a `justfile` at the repo root with the standard development recipes specified in #2.

Recipes (matches the issue acceptance criteria verbatim):

- `default` — `just --list`
- `build` — `cargo build --all`
- `build-release` — `cargo build --release --all`
- `test` — `cargo test --all`
- `fmt` — `cargo fmt --all`
- `fmt-check` — `cargo fmt --all -- --check`
- `lint` — `cargo clippy --all-targets --all-features -- -D warnings`
- `check` — `cargo check --all`
- `run *args` — `cargo run -p scribe -- {{args}}`
- `doctor` — `cargo run -p scribe -- doctor`
- `install` — `cargo install --path crates/scribe`
- `clean` — `cargo clean`
- `release-dry-run` — `echo "see #4"` (placeholder until #4 lands)

Recipes are grouped under `# ---` section headers (Build / Test & checks / Formatting & lint / Run / Install & housekeeping / Release) for tidy `just --list` output.

## Test plan

- [x] `just --list` renders cleanly
- [x] `just fmt-check` passes against current scaffolding
- [x] `just lint` passes (clippy clean, `-D warnings`)
- [x] `just test` passes (3 tests, all ok)

Closes #2.