### PR TITLE
ci: tag-driven release pipeline (linux x86_64 + linux aarch64 + macos aarch64)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,196 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (build artifacts but do not create a GitHub Release)'
+        required: false
+        default: true
+        type: boolean
+
+env:
+  CARGO_TERM_COLOR: always
+
+permissions:
+  contents: write
+
+jobs:
+  create-release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      is_tag: ${{ steps.version.outputs.is_tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version
+        id: version
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/v}"
+            echo "is_tag=true" >> "$GITHUB_OUTPUT"
+          else
+            VERSION="0.0.0-dev"
+            echo "is_tag=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Version: $VERSION"
+
+      - name: Generate changelog
+        id: changelog
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+            if [ -z "$PREV_TAG" ]; then
+              echo "First release - including all commits"
+              git log --pretty=format:"- %s (%h)" --no-merges > changelog.txt
+            else
+              echo "Previous tag: $PREV_TAG"
+              git log "${PREV_TAG}..HEAD" --pretty=format:"- %s (%h)" --no-merges > changelog.txt
+            fi
+          else
+            echo "Dry run - no changelog generated" > changelog.txt
+          fi
+          echo "--- changelog.txt ---"
+          cat changelog.txt
+          echo
+          echo "--- end changelog ---"
+
+      - name: Upload changelog artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: changelog
+          path: changelog.txt
+          retention-days: 7
+
+      - name: Create GitHub Release
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ steps.version.outputs.version }}
+          body_path: changelog.txt
+          draft: false
+          prerelease: ${{ contains(steps.version.outputs.version, '-') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-binaries:
+    name: Build (${{ matrix.target }})
+    needs: create-release
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            use_cross: false
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            use_cross: true
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            use_cross: false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cross
+        if: matrix.use_cross == true
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
+
+      - name: Cache cargo registry and git
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target }}-cargo-
+
+      - name: Cache cargo build target
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-${{ matrix.target }}-build-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target }}-build-
+
+      - name: Build (cargo)
+        if: matrix.use_cross == false
+        run: cargo build --release --target ${{ matrix.target }} --bin scribe
+
+      - name: Build (cross)
+        if: matrix.use_cross == true
+        run: cross build --release --target ${{ matrix.target }} --bin scribe
+
+      - name: Package archive
+        shell: bash
+        run: |
+          set -euo pipefail
+          TARGET="${{ matrix.target }}"
+          ARCHIVE_NAME="scribe-${TARGET}"
+          STAGING="dist/${ARCHIVE_NAME}"
+
+          mkdir -p "${STAGING}"
+          cp "target/${TARGET}/release/scribe" "${STAGING}/scribe"
+          cp LICENSE-MIT "${STAGING}/LICENSE-MIT"
+          cp LICENSE-APACHE "${STAGING}/LICENSE-APACHE"
+          cp README.md "${STAGING}/README.md"
+
+          tar -C dist -czf "${ARCHIVE_NAME}.tar.gz" "${ARCHIVE_NAME}"
+          echo "ARCHIVE_PATH=${ARCHIVE_NAME}.tar.gz" >> "$GITHUB_ENV"
+          echo "ARCHIVE_NAME=${ARCHIVE_NAME}" >> "$GITHUB_ENV"
+
+          ls -lah "${ARCHIVE_NAME}.tar.gz"
+
+      - name: Upload dry-run artifact
+        if: needs.create-release.outputs.is_tag != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.ARCHIVE_NAME }}
+          path: ${{ env.ARCHIVE_PATH }}
+          retention-days: 7
+
+      - name: Attach asset to GitHub Release
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          files: ${{ env.ARCHIVE_PATH }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  dry-run-summary:
+    name: Dry Run Summary
+    needs: [create-release, build-binaries]
+    runs-on: ubuntu-latest
+    if: needs.create-release.outputs.is_tag != 'true'
+    steps:
+      - name: Summary
+        run: |
+          {
+            echo "## Dry run completed"
+            echo ""
+            echo "Version: \`${{ needs.create-release.outputs.version }}\`"
+            echo ""
+            echo "No GitHub Release was created. Per-target archives are available as workflow artifacts."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release.yml` implementing the tag-driven release pipeline specified in issue #4.

- Triggers on `push` of `v*` tags, plus `workflow_dispatch` with a `dry_run` boolean input (default `true`).
- `create-release` job: extracts version from tag, generates changelog from `git log <prev-tag>..HEAD`, creates a GitHub Release (skipped on dry run).
- `build-binaries` job: 3-target matrix
  - `x86_64-unknown-linux-gnu` on `ubuntu-latest` (native cargo)
  - `aarch64-unknown-linux-gnu` on `ubuntu-latest` via `cross-rs/cross`
  - `aarch64-apple-darwin` on `macos-latest` (native cargo, no cross needed)
- Each archive is `scribe-<target>.tar.gz` containing `scribe` + `LICENSE-MIT` + `LICENSE-APACHE` + `README.md`.
- On dry run, archives upload as workflow artifacts instead of release assets.

## Deviations from the scryforge pattern

- Trimmed `x86_64-unknown-linux-musl`, `x86_64-apple-darwin`, and `x86_64-pc-windows-msvc` matrix entries (out of scope).
- Dropped the `publish-crates` job entirely (out of scope per issue).
- Replaced the deprecated `actions/create-release@v1` + `actions/upload-release-asset@v1` pair with `softprops/action-gh-release@v2`, which is the maintained equivalent and handles both release creation and asset upload. The two-job structure (`create-release` then `build-binaries`) is preserved.
- Bumped `actions/cache` v3 -> v4 and `actions/upload-artifact` v3 -> v4 (v3 is sunset).
- Asset filenames are `scribe-<target>.tar.gz` (no embedded version, per the issue's exact spec) rather than scryforge's `scryforge-<version>-<target>.tar.gz`.

## Test plan

- [ ] YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` -> ok locally).
- [ ] `workflow_dispatch` with `dry_run=true` runs all matrix targets and uploads three artifacts.
- [ ] Future tag push (`v0.x.y`) creates a Release with three attached `scribe-<target>.tar.gz` assets.

Closes #4

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>