### PR TITLE
feat: scribe doctor — verify ffmpeg / whisper-cli / model presence

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,6 @@ serde_json = "1.0"
 # Logging
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+# Filesystem helpers
+dirs = "5.0"

--- a/crates/scribe/Cargo.toml
+++ b/crates/scribe/Cargo.toml
@@ -18,3 +18,7 @@ serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+dirs.workspace = true
+
+[dev-dependencies]
+tempfile = "3.10"

--- a/crates/scribe/src/doctor.rs
+++ b/crates/scribe/src/doctor.rs
@@ -1,0 +1,334 @@
+//! `scribe doctor` — verify that the external dependencies the transcribe
+//! pipeline relies on are present.
+//!
+//! Checks performed (each emits a `tracing` line at info / warn / error):
+//!
+//! 1. `ffmpeg` — must be on `PATH`. Reports the first line of `ffmpeg -version`.
+//! 2. `whisper-cli` — looked up via `$SCRIBE_WHISPER_BIN`, falling back to
+//!    `~/raibid-labs/voice-stuff/third_party/whisper.cpp/build/bin/whisper-cli`.
+//! 3. `model` — directory looked up via `$SCRIBE_MODEL_PATH`, falling back to
+//!    `~/raibid-labs/voice-stuff/models/`. Lists every `*.bin` file found.
+//! 4. `GPU` — `nvidia-smi --query-gpu=name --format=csv,noheader`. Non-fatal.
+//!
+//! Returns `Ok(true)` if every fatal check passes, `Ok(false)` if any of
+//! ffmpeg / whisper-cli / model is missing. The caller (in `main.rs`) maps
+//! that boolean to an exit code.
+//!
+//! Nothing in this module mutates the host. No installs, no model fetches.
+//! Remediation is documented in `docs/06-troubleshooting.md`.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use tracing::{error, info, warn};
+
+use crate::which::{is_executable_file, probe, which_on_path};
+
+/// Env var holding an explicit path to the `whisper-cli` binary.
+pub const ENV_WHISPER_BIN: &str = "SCRIBE_WHISPER_BIN";
+/// Env var holding an explicit path to the model directory.
+pub const ENV_MODEL_PATH: &str = "SCRIBE_MODEL_PATH";
+
+/// Default location of the `whisper-cli` binary, relative to `$HOME`.
+pub const DEFAULT_WHISPER_BIN_REL: &str =
+    "raibid-labs/voice-stuff/third_party/whisper.cpp/build/bin/whisper-cli";
+/// Default location of the model directory, relative to `$HOME`.
+pub const DEFAULT_MODEL_DIR_REL: &str = "raibid-labs/voice-stuff/models";
+
+/// Run every doctor check and return `Ok(true)` if the host is healthy enough
+/// to transcribe. GPU absence is non-fatal.
+pub fn run() -> Result<bool> {
+    let ffmpeg_ok = check_ffmpeg();
+    let whisper_ok = check_whisper_cli();
+    let model_ok = check_model();
+    let _gpu_ok = check_gpu(); // non-fatal
+
+    let healthy = ffmpeg_ok && whisper_ok && model_ok;
+    if healthy {
+        info!("doctor: all required dependencies present");
+    } else {
+        warn!("doctor: one or more required dependencies missing — see lines above");
+    }
+    Ok(healthy)
+}
+
+/// Resolve the configured whisper-cli path: env var first, then default
+/// under `$HOME`. Returns `None` if `$HOME` is unset *and* the env var is
+/// also unset (extremely unusual).
+pub fn resolve_whisper_bin() -> Option<PathBuf> {
+    if let Some(p) = nonempty_env(ENV_WHISPER_BIN) {
+        return Some(p);
+    }
+    Some(dirs::home_dir()?.join(DEFAULT_WHISPER_BIN_REL))
+}
+
+/// Resolve the configured model directory: env var first, then default
+/// under `$HOME`. Returns `None` if `$HOME` is unset and the env var is
+/// also unset.
+pub fn resolve_model_dir() -> Option<PathBuf> {
+    if let Some(p) = nonempty_env(ENV_MODEL_PATH) {
+        return Some(p);
+    }
+    Some(dirs::home_dir()?.join(DEFAULT_MODEL_DIR_REL))
+}
+
+fn nonempty_env(key: &str) -> Option<PathBuf> {
+    match std::env::var_os(key) {
+        Some(v) if !v.is_empty() => Some(PathBuf::from(v)),
+        _ => None,
+    }
+}
+
+/// List every `*.bin` entry in `dir` that resolves to a regular file, sorted.
+///
+/// Symlinks are followed (`std::fs::metadata`, not `symlink_metadata`) so a
+/// `models/ggml-base.en.bin` symlink into `whisper.cpp/models/` counts —
+/// that's how voice-stuff lays its model dir out.
+pub fn list_bin_files(dir: &Path) -> Vec<PathBuf> {
+    let Ok(read) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut out: Vec<PathBuf> = read
+        .flatten()
+        .filter_map(|e| {
+            let p = e.path();
+            let is_bin = p.extension().and_then(|s| s.to_str()) == Some("bin");
+            if !is_bin {
+                return None;
+            }
+            // Follow symlinks: voice-stuff symlinks ggml-*.bin into ./models/.
+            let resolves_to_file = std::fs::metadata(&p).map(|m| m.is_file()).unwrap_or(false);
+            resolves_to_file.then_some(p)
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+fn check_ffmpeg() -> bool {
+    let Some(path) = which_on_path("ffmpeg") else {
+        error!(
+            "ffmpeg: MISSING on PATH (install via `apt install ffmpeg` or `brew install ffmpeg`)"
+        );
+        return false;
+    };
+    match probe(&path, ["-version"]) {
+        Ok(out) => {
+            info!("ffmpeg: {} ({})", path.display(), out.first_line);
+            true
+        }
+        Err(e) => {
+            error!(
+                "ffmpeg: found at {} but failed to execute: {}",
+                path.display(),
+                e
+            );
+            false
+        }
+    }
+}
+
+fn check_whisper_cli() -> bool {
+    let Some(path) = resolve_whisper_bin() else {
+        error!(
+            "whisper-cli: cannot resolve path (no ${} and no $HOME)",
+            ENV_WHISPER_BIN
+        );
+        return false;
+    };
+    if !is_executable_file(&path) {
+        error!(
+            "whisper-cli: MISSING at {} (set ${} or build whisper.cpp — see docs/06-troubleshooting.md)",
+            path.display(),
+            ENV_WHISPER_BIN
+        );
+        return false;
+    }
+    // whisper-cli has no --version flag; --help prints the usage banner,
+    // which is enough to confirm the binary is the one we expect and runs.
+    match probe(&path, ["--help"]) {
+        Ok(out) => {
+            info!("whisper-cli: {} ({})", path.display(), out.first_line);
+            true
+        }
+        Err(e) => {
+            error!(
+                "whisper-cli: found at {} but failed to execute: {}",
+                path.display(),
+                e
+            );
+            false
+        }
+    }
+}
+
+fn check_model() -> bool {
+    let Some(dir) = resolve_model_dir() else {
+        error!(
+            "model: cannot resolve model dir (no ${} and no $HOME)",
+            ENV_MODEL_PATH
+        );
+        return false;
+    };
+    if !dir.is_dir() {
+        error!(
+            "model: directory MISSING at {} (set ${} or fetch a model — see docs/06-troubleshooting.md)",
+            dir.display(),
+            ENV_MODEL_PATH
+        );
+        return false;
+    }
+    let bins = list_bin_files(&dir);
+    if bins.is_empty() {
+        error!(
+            "model: no *.bin files in {} (run `just fetch-model base.en` in voice-stuff)",
+            dir.display()
+        );
+        return false;
+    }
+    let names: Vec<String> = bins
+        .iter()
+        .filter_map(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
+        .collect();
+    info!(
+        "model: {} ({} found: {})",
+        dir.display(),
+        bins.len(),
+        names.join(", ")
+    );
+    true
+}
+
+fn check_gpu() -> bool {
+    let Some(path) = which_on_path("nvidia-smi") else {
+        info!("GPU: n/a (nvidia-smi not on PATH)");
+        return false;
+    };
+    match probe(&path, ["--query-gpu=name", "--format=csv,noheader"]) {
+        Ok(out) if out.exit_code == Some(0) && !out.first_line.is_empty() => {
+            info!("GPU: {}", out.first_line);
+            true
+        }
+        Ok(out) => {
+            // nvidia-smi present but reported no devices or non-zero exit.
+            info!(
+                "GPU: n/a (nvidia-smi exit={:?}, output={:?})",
+                out.exit_code, out.first_line
+            );
+            false
+        }
+        Err(e) => {
+            info!("GPU: n/a (nvidia-smi failed: {})", e);
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_whisper_bin_prefers_env() {
+        let key = ENV_WHISPER_BIN;
+        let prev = std::env::var_os(key);
+        std::env::set_var(key, "/custom/whisper-cli");
+        let p = resolve_whisper_bin().unwrap();
+        // Restore *before* asserting, so a panic doesn't leak state.
+        match prev {
+            Some(v) => std::env::set_var(key, v),
+            None => std::env::remove_var(key),
+        }
+        assert_eq!(p, PathBuf::from("/custom/whisper-cli"));
+    }
+
+    #[test]
+    fn resolve_whisper_bin_uses_default() {
+        let key = ENV_WHISPER_BIN;
+        let prev = std::env::var_os(key);
+        std::env::remove_var(key);
+        let p = resolve_whisper_bin();
+        match prev {
+            Some(v) => std::env::set_var(key, v),
+            None => std::env::remove_var(key),
+        }
+        let p = p.expect("HOME must be set in test env");
+        assert!(p.ends_with(DEFAULT_WHISPER_BIN_REL));
+        assert!(p.is_absolute());
+    }
+
+    #[test]
+    fn resolve_model_dir_prefers_env() {
+        let key = ENV_MODEL_PATH;
+        let prev = std::env::var_os(key);
+        std::env::set_var(key, "/custom/models");
+        let p = resolve_model_dir().unwrap();
+        match prev {
+            Some(v) => std::env::set_var(key, v),
+            None => std::env::remove_var(key),
+        }
+        assert_eq!(p, PathBuf::from("/custom/models"));
+    }
+
+    #[test]
+    fn resolve_model_dir_uses_default() {
+        let key = ENV_MODEL_PATH;
+        let prev = std::env::var_os(key);
+        std::env::remove_var(key);
+        let p = resolve_model_dir();
+        match prev {
+            Some(v) => std::env::set_var(key, v),
+            None => std::env::remove_var(key),
+        }
+        let p = p.expect("HOME must be set in test env");
+        assert!(p.ends_with(DEFAULT_MODEL_DIR_REL));
+        assert!(p.is_absolute());
+    }
+
+    #[test]
+    fn list_bin_files_returns_empty_for_missing_dir() {
+        let p = Path::new("/definitely/does/not/exist/scribe-doctor-test");
+        assert!(list_bin_files(p).is_empty());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn list_bin_files_follows_symlinks_to_regular_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        // Real .bin lives in a sibling dir; the model dir holds only a symlink.
+        let real_dir = tempfile::tempdir().unwrap();
+        let real_bin = real_dir.path().join("ggml-base.en.bin");
+        std::fs::write(&real_bin, b"fake-model-bytes").unwrap();
+        std::os::unix::fs::symlink(&real_bin, dir.join("ggml-base.en.bin")).unwrap();
+
+        // Also a dangling symlink that should NOT count.
+        std::os::unix::fs::symlink("/nonexistent/path.bin", dir.join("dangling.bin")).unwrap();
+
+        let bins = list_bin_files(dir);
+        let names: Vec<String> = bins
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(names, vec!["ggml-base.en.bin"]);
+    }
+
+    #[test]
+    fn list_bin_files_filters_extensions_and_sorts() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        // Create a mix: two .bin, one .txt, one .gguf, plus a subdir.
+        std::fs::write(dir.join("zeta.bin"), b"x").unwrap();
+        std::fs::write(dir.join("alpha.bin"), b"x").unwrap();
+        std::fs::write(dir.join("notes.txt"), b"x").unwrap();
+        std::fs::write(dir.join("model.gguf"), b"x").unwrap();
+        std::fs::create_dir(dir.join("nested.bin")).unwrap();
+
+        let bins = list_bin_files(dir);
+        let names: Vec<String> = bins
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(names, vec!["alpha.bin", "zeta.bin"]);
+    }
+}

--- a/crates/scribe/src/main.rs
+++ b/crates/scribe/src/main.rs
@@ -1,15 +1,18 @@
 //! Scribe CLI entry point.
 //!
-//! This is the v0.1 skeleton: clap-derived top-level CLI with `transcribe`
-//! and `doctor` subcommands. Both subcommands are stubs that print
-//! "not implemented" and exit 0. The real pipeline lands in issues #5
-//! (`doctor`) and #6 (`transcribe`).
+//! Top-level clap-derived CLI with `transcribe` and `doctor` subcommands.
+//! `doctor` is fully wired (issue #5); `transcribe` is still the v0.1
+//! stub awaiting issue #6.
 
 use std::path::PathBuf;
+use std::process::ExitCode;
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 use tracing_subscriber::EnvFilter;
+
+mod doctor;
+mod which;
 
 /// Verbatim audio-to-Markdown transcription CLI.
 ///
@@ -46,14 +49,28 @@ struct TranscribeArgs {
     model: Option<String>,
 }
 
-fn main() -> Result<()> {
+fn main() -> ExitCode {
     init_tracing();
 
     let cli = Cli::parse();
 
-    match cli.command {
-        Command::Transcribe(args) => run_transcribe(args),
-        Command::Doctor => run_doctor(),
+    let result: Result<ExitCode> = match cli.command {
+        Command::Transcribe(args) => run_transcribe(args).map(|_| ExitCode::SUCCESS),
+        Command::Doctor => run_doctor().map(|healthy| {
+            if healthy {
+                ExitCode::SUCCESS
+            } else {
+                ExitCode::from(1)
+            }
+        }),
+    };
+
+    match result {
+        Ok(code) => code,
+        Err(e) => {
+            tracing::error!("{:#}", e);
+            ExitCode::from(1)
+        }
     }
 }
 
@@ -70,7 +87,6 @@ fn run_transcribe(_args: TranscribeArgs) -> Result<()> {
     Ok(())
 }
 
-fn run_doctor() -> Result<()> {
-    println!("scribe doctor: not implemented");
-    Ok(())
+fn run_doctor() -> Result<bool> {
+    doctor::run()
 }

--- a/crates/scribe/src/which.rs
+++ b/crates/scribe/src/which.rs
@@ -1,0 +1,185 @@
+//! Subprocess + filesystem lookup helpers.
+//!
+//! General-purpose wrappers around [`std::process::Command`] used by the
+//! `doctor` subcommand to verify external dependencies. Designed to be reused
+//! by the `transcribe` pipeline (issue #6) when it needs to locate
+//! `ffmpeg` and `whisper-cli`.
+//!
+//! Nothing in this module mutates the host: no installs, no downloads, no
+//! filesystem writes. Lookups only.
+
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Result of probing an external binary for its identifying banner.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProbeOutput {
+    /// First non-empty line of stdout (or stderr if stdout was empty).
+    /// Useful as a "version line" surrogate for tools that don't expose
+    /// a real `--version` flag.
+    pub first_line: String,
+    /// Process exit code, or `None` if the process was killed by a signal.
+    pub exit_code: Option<i32>,
+}
+
+/// Look up a binary on `PATH` the same way the shell would.
+///
+/// Returns the resolved absolute path on success, or `None` if the binary is
+/// not found. This is a minimal reimplementation of the `which` crate so we
+/// don't pull in a dependency just for this.
+pub fn which_on_path(name: &str) -> Option<PathBuf> {
+    let path_var = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path_var) {
+        let candidate = dir.join(name);
+        if is_executable_file(&candidate) {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+/// Resolve a binary path using an environment variable override, falling back
+/// to a default path if the env var is unset or empty.
+///
+/// The returned path is *not* validated — callers should follow up with
+/// [`is_executable_file`] (or run the binary) to confirm it actually works.
+///
+/// Currently unused by `doctor` (which needs to combine env-var lookup with
+/// `dirs::home_dir()` and so handles its own resolution), but kept here for
+/// the `transcribe` pipeline (issue #6), which will resolve absolute paths
+/// to ffmpeg / whisper-cli the same way.
+#[allow(dead_code)]
+pub fn env_or_default<P: Into<PathBuf>>(env_var: &str, default: P) -> PathBuf {
+    match std::env::var_os(env_var) {
+        Some(v) if !v.is_empty() => PathBuf::from(v),
+        _ => default.into(),
+    }
+}
+
+/// Return true if `path` exists, is a regular file, and is marked executable
+/// for the current user (or any executable bit on Unix).
+pub fn is_executable_file(path: &Path) -> bool {
+    let Ok(meta) = std::fs::metadata(path) else {
+        return false;
+    };
+    if !meta.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        meta.permissions().mode() & 0o111 != 0
+    }
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}
+
+/// Run a binary with the given args and capture its first line of output.
+///
+/// Combines stdout and stderr (preferring stdout) so we can identify tools
+/// that print their banner to either stream. Returns `Err` only if the
+/// process could not be spawned at all.
+pub fn probe<I, S>(bin: &Path, args: I) -> std::io::Result<ProbeOutput>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let output = Command::new(bin).args(args).output()?;
+    let first_line = first_nonempty_line(&output.stdout)
+        .or_else(|| first_nonempty_line(&output.stderr))
+        .unwrap_or_default();
+    Ok(ProbeOutput {
+        first_line,
+        exit_code: output.status.code(),
+    })
+}
+
+fn first_nonempty_line(buf: &[u8]) -> Option<String> {
+    let text = String::from_utf8_lossy(buf);
+    text.lines()
+        .map(str::trim_end)
+        .find(|l| !l.is_empty())
+        .map(|s| s.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn env_or_default_prefers_env() {
+        // SAFETY: tests are single-threaded for env access by default; if we
+        // ever flip to multi-threaded test runners, swap this for a serial_test.
+        let key = "SCRIBE_TEST_ENV_OR_DEFAULT_PREFERS_ENV";
+        std::env::set_var(key, "/tmp/from-env");
+        let p = env_or_default(key, "/tmp/default");
+        std::env::remove_var(key);
+        assert_eq!(p, PathBuf::from("/tmp/from-env"));
+    }
+
+    #[test]
+    fn env_or_default_falls_back_when_unset() {
+        let key = "SCRIBE_TEST_ENV_OR_DEFAULT_FALLS_BACK_WHEN_UNSET";
+        std::env::remove_var(key);
+        let p = env_or_default(key, "/tmp/default");
+        assert_eq!(p, PathBuf::from("/tmp/default"));
+    }
+
+    #[test]
+    fn env_or_default_falls_back_when_empty() {
+        let key = "SCRIBE_TEST_ENV_OR_DEFAULT_FALLS_BACK_WHEN_EMPTY";
+        std::env::set_var(key, "");
+        let p = env_or_default(key, "/tmp/default");
+        std::env::remove_var(key);
+        assert_eq!(p, PathBuf::from("/tmp/default"));
+    }
+
+    #[test]
+    fn first_nonempty_line_skips_blanks() {
+        let s = first_nonempty_line(b"\n\n  \nhello\nworld\n").unwrap();
+        assert_eq!(s, "hello");
+    }
+
+    #[test]
+    fn first_nonempty_line_handles_empty_input() {
+        assert!(first_nonempty_line(b"").is_none());
+        assert!(first_nonempty_line(b"\n\n").is_none());
+    }
+
+    #[test]
+    fn is_executable_file_rejects_missing() {
+        assert!(!is_executable_file(Path::new(
+            "/definitely/does/not/exist/scribe-test"
+        )));
+    }
+
+    #[test]
+    fn is_executable_file_detects_real_binary() {
+        // /bin/sh exists and is executable on every supported platform.
+        assert!(is_executable_file(Path::new("/bin/sh")));
+    }
+
+    #[test]
+    fn which_on_path_finds_sh() {
+        // `sh` should always be resolvable on a POSIX host.
+        let p = which_on_path("sh").expect("sh must be on PATH");
+        assert!(p.is_absolute());
+        assert!(is_executable_file(&p));
+    }
+
+    #[test]
+    fn which_on_path_returns_none_for_garbage() {
+        assert!(which_on_path("scribe-definitely-not-a-real-binary-xyz").is_none());
+    }
+
+    #[test]
+    fn probe_captures_first_line_of_sh() {
+        let sh = which_on_path("sh").expect("sh must be on PATH");
+        let out = probe(&sh, ["-c", "echo first; echo second"]).unwrap();
+        assert_eq!(out.first_line, "first");
+        assert_eq!(out.exit_code, Some(0));
+    }
+}


### PR DESCRIPTION
Closes #5.

## Summary

Replaces the `doctor` stub with a working dependency-verification subcommand. Each check emits a `tracing` line at info / warn / error.

| Check | Source | Default |
| --- | --- | --- |
| `ffmpeg` | `which ffmpeg` on `PATH` | n/a |
| `whisper-cli` | `$SCRIBE_WHISPER_BIN` | `~/raibid-labs/voice-stuff/third_party/whisper.cpp/build/bin/whisper-cli` |
| `model` | `$SCRIBE_MODEL_PATH` | `~/raibid-labs/voice-stuff/models/` (lists `*.bin`, follows symlinks) |
| `GPU` | `nvidia-smi --query-gpu=name --format=csv,noheader` | non-fatal; `n/a` if absent |

Exit code: `0` when all fatal checks pass (or only GPU missing); `1` if `ffmpeg`, `whisper-cli`, or `model` is missing.

`whisper-cli` has no `--version` flag (verified via `--help`), so we capture the first line of `--help` output as the identifier — that's enough to confirm the binary runs and is the right tool. The same idea would be used for `ffmpeg -version`.

## Module layout

- `crates/scribe/src/doctor.rs` — `pub fn run() -> anyhow::Result<bool>`, four `check_*` functions, env-var-or-default resolution helpers, `list_bin_files` (follows symlinks because voice-stuff symlinks `ggml-*.bin` into `./models/`).
- `crates/scribe/src/which.rs` — general subprocess + `PATH` lookup helpers (`which_on_path`, `is_executable_file`, `probe`, `env_or_default`). Designed for reuse by issue #6's transcribe pipeline; `env_or_default` is currently `#[allow(dead_code)]` with a comment noting it's there for #6.
- `crates/scribe/src/main.rs` — `doctor` is wired to `doctor::run()`; `main` now returns `ExitCode` so a non-healthy doctor produces exit 1.

## Tests

- `cargo test --all`: 17 unit + 3 existing integration, all green.
- Pure helpers covered: env-var-or-default precedence (env / unset / empty), path resolution under `$HOME`, `list_bin_files` (extension filter, sort order, symlink-follow, dangling-symlink rejection), `which_on_path`, `probe` first-line capture, executable detection.
- Subprocess interaction (`ffmpeg -version`, `whisper-cli --help`, `nvidia-smi`) is deliberately *not* unit-tested — that's integration territory and is owned by issue #7.

## Verification on this host

```
$ cargo run -p scribe -- doctor
INFO ffmpeg: /usr/bin/ffmpeg (ffmpeg version 6.1.1-3ubuntu5+esm7 Copyright (c) 2000-2023 the FFmpeg developers)
INFO whisper-cli: /home/beengud/raibid-labs/voice-stuff/third_party/whisper.cpp/build/bin/whisper-cli (usage: /home/beengud/raibid-labs/voice-stuff/third_party/whisper.cpp/build/bin/whisper-cli [options] file0 file1 ...)
INFO model: /home/beengud/raibid-labs/voice-stuff/models (1 found: ggml-base.en.bin)
INFO GPU: NVIDIA GB10
INFO doctor: all required dependencies present
$ echo $?
0
```

Failure path (forced via env vars):

```
$ SCRIBE_WHISPER_BIN=/nope SCRIBE_MODEL_PATH=/nope cargo run -p scribe -- doctor
INFO  ffmpeg: /usr/bin/ffmpeg (ffmpeg version 6.1.1-...)
ERROR whisper-cli: MISSING at /nope (set $SCRIBE_WHISPER_BIN or build whisper.cpp — see docs/06-troubleshooting.md)
ERROR model: directory MISSING at /nope (set $SCRIBE_MODEL_PATH or fetch a model — see docs/06-troubleshooting.md)
INFO  GPU: NVIDIA GB10
WARN  doctor: one or more required dependencies missing — see lines above
$ echo $?
1
```

## Out of scope

- Auto-installing missing dependencies (per spec).
- Auto-fetching missing models (per spec).
- The `transcribe` pipeline — that's #6.
- Subprocess integration tests against fixtures — that's #7.

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --all` (17 unit + 3 integration) green
- [x] `cargo run -p scribe -- doctor` exits 0 on this host with all four checks reporting
- [x] forced-failure path (`SCRIBE_WHISPER_BIN=/nope SCRIBE_MODEL_PATH=/nope`) exits 1 with error lines
- [ ] reviewer to spot-check on a host without ffmpeg / without GPU