### PR TITLE
feat: scribe transcribe — ffmpeg + whisper.cpp pipeline → .md + .json

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,9 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # Filesystem helpers
 dirs = "5.0"
+
+# Temp file management for the transcribe pipeline's intermediate WAV.
+tempfile = "3.10"
+
+# Timestamp formatting for transcript filenames + frontmatter.
+chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }

--- a/crates/scribe/Cargo.toml
+++ b/crates/scribe/Cargo.toml
@@ -19,6 +19,8 @@ serde_json.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 dirs.workspace = true
+tempfile.workspace = true
+chrono.workspace = true
 
 [dev-dependencies]
-tempfile = "3.10"
+tempfile.workspace = true

--- a/crates/scribe/src/config.rs
+++ b/crates/scribe/src/config.rs
@@ -1,0 +1,383 @@
+//! Resolution of `scribe transcribe` runtime configuration.
+//!
+//! Combines CLI flags with environment variables and built-in defaults,
+//! producing a [`Config`] that the rest of the pipeline consumes without
+//! re-reading the environment. Flag values always win over env vars.
+//!
+//! Env vars honored (also documented in `docs/04-cli-reference.md`):
+//!
+//! - `SCRIBE_MODEL` — default model name when `--model` is not passed.
+//! - `SCRIBE_MODEL_PATH` — directory to resolve model names against.
+//! - `SCRIBE_WHISPER_BIN` — path to the `whisper-cli` binary.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, Context, Result};
+
+use crate::doctor::{resolve_model_dir, DEFAULT_WHISPER_BIN_REL, ENV_MODEL_PATH, ENV_WHISPER_BIN};
+use crate::which::{env_or_default, is_executable_file};
+
+/// Env var holding the default model *name* (e.g. `large-v3`).
+pub const ENV_MODEL: &str = "SCRIBE_MODEL";
+
+/// Built-in default model name when neither `--model` nor `SCRIBE_MODEL`
+/// is set. Picked because it's the default model the voice-stuff justfile
+/// fetches and what `scribe doctor` is likely to find on this host.
+pub const DEFAULT_MODEL_NAME: &str = "base.en";
+
+/// Fully-resolved configuration for one `scribe transcribe` invocation.
+///
+/// All paths in here are absolute and have been validated to the extent
+/// possible without spawning subprocesses (binary executable, model file
+/// exists). The pipeline trusts these unconditionally.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Config {
+    /// Absolute path to the input audio/video file.
+    pub input: PathBuf,
+    /// Absolute path to the output directory (created if missing).
+    pub out_dir: PathBuf,
+    /// Resolved logical model name (e.g. `base.en`, `large-v3`).
+    pub model_name: String,
+    /// Absolute path to the model `.bin` file, resolved against
+    /// `$SCRIBE_MODEL_PATH` (or its default).
+    pub model_path: PathBuf,
+    /// Absolute path to the `whisper-cli` binary.
+    pub whisper_bin: PathBuf,
+    /// If true, the intermediate 16 kHz WAV is preserved for debugging.
+    pub keep_temp: bool,
+}
+
+/// Inputs sourced from CLI flags, mirrored from `TranscribeArgs` in `main.rs`.
+///
+/// Kept as a separate struct so `Config::resolve` is easy to unit-test
+/// without dragging clap-derived types into the test harness.
+#[derive(Debug, Clone)]
+pub struct CliInputs {
+    pub input: PathBuf,
+    pub out_dir: PathBuf,
+    pub model: Option<String>,
+    pub keep_temp: bool,
+}
+
+impl Config {
+    /// Resolve a complete [`Config`] from CLI flags + the process environment.
+    ///
+    /// Side effects: canonicalizes `--input` (must already exist), creates
+    /// `--out-dir` if missing then canonicalizes it, resolves the model file
+    /// against `$SCRIBE_MODEL_PATH`, and validates that the whisper-cli
+    /// binary exists and is executable.
+    pub fn resolve(cli: CliInputs) -> Result<Self> {
+        // --input must exist; canonicalize so the source frontmatter field
+        // is an absolute path that survives `cd` from the consumer.
+        let input = cli
+            .input
+            .canonicalize()
+            .with_context(|| format!("input file not found: {}", cli.input.display()))?;
+
+        // --out-dir is created if missing (mkdir -p semantics), then canonicalized.
+        std::fs::create_dir_all(&cli.out_dir)
+            .with_context(|| format!("failed to create out-dir: {}", cli.out_dir.display()))?;
+        let out_dir = cli
+            .out_dir
+            .canonicalize()
+            .with_context(|| format!("failed to resolve out-dir: {}", cli.out_dir.display()))?;
+
+        // Model name precedence: --model > $SCRIBE_MODEL > DEFAULT_MODEL_NAME.
+        let model_name = match cli.model {
+            Some(n) if !n.trim().is_empty() => n,
+            _ => env_var_nonempty(ENV_MODEL).unwrap_or_else(|| DEFAULT_MODEL_NAME.to_string()),
+        };
+
+        // Resolve the .bin file under $SCRIBE_MODEL_PATH (or its default).
+        let model_dir = resolve_model_dir().ok_or_else(|| {
+            anyhow!(
+                "cannot resolve model directory (no ${} and no $HOME)",
+                ENV_MODEL_PATH
+            )
+        })?;
+        let model_path = resolve_model_path(&model_dir, &model_name).with_context(|| {
+            format!(
+                "model `{model_name}` not found in {} (looked for ggml-{model_name}.bin and {model_name}.bin)",
+                model_dir.display(),
+            )
+        })?;
+
+        // whisper-cli: $SCRIBE_WHISPER_BIN > default. Use env_or_default
+        // (now load-bearing — drops the dead-code suppression in which.rs).
+        let whisper_bin = match dirs::home_dir() {
+            Some(home) => env_or_default(ENV_WHISPER_BIN, home.join(DEFAULT_WHISPER_BIN_REL)),
+            None => PathBuf::from(env_var_nonempty(ENV_WHISPER_BIN).ok_or_else(|| {
+                anyhow!("cannot resolve whisper-cli (no ${ENV_WHISPER_BIN} and no $HOME)")
+            })?),
+        };
+        if !is_executable_file(&whisper_bin) {
+            return Err(anyhow!(
+                "whisper-cli not found or not executable at {} (set ${} or build whisper.cpp — see docs/06-troubleshooting.md)",
+                whisper_bin.display(),
+                ENV_WHISPER_BIN
+            ));
+        }
+
+        Ok(Self {
+            input,
+            out_dir,
+            model_name,
+            model_path,
+            whisper_bin,
+            keep_temp: cli.keep_temp,
+        })
+    }
+}
+
+/// Look up a model `.bin` by logical name in `dir`.
+///
+/// Tries `<dir>/ggml-<name>.bin` first (matches the voice-stuff layout),
+/// then `<dir>/<name>.bin` for users who name their files explicitly.
+/// Returns `None` if neither exists or `dir` is not a directory.
+pub fn resolve_model_path(dir: &Path, name: &str) -> Option<PathBuf> {
+    let ggml_form = dir.join(format!("ggml-{name}.bin"));
+    if ggml_form.is_file() {
+        return Some(ggml_form);
+    }
+    let plain_form = dir.join(format!("{name}.bin"));
+    if plain_form.is_file() {
+        return Some(plain_form);
+    }
+    // Also accept the case where the user passed a name that already has
+    // the extension (e.g. `--model ggml-base.en.bin`).
+    let literal = dir.join(name);
+    if literal.is_file() {
+        return Some(literal);
+    }
+    None
+}
+
+fn env_var_nonempty(key: &str) -> Option<String> {
+    match std::env::var(key) {
+        Ok(v) if !v.is_empty() => Some(v),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::which::ENV_TEST_LOCK as ENV_LOCK;
+
+    /// Set/unset one env var around a closure, restoring prior state on exit.
+    /// Caller must hold [`ENV_LOCK`] before calling — these tests touch
+    /// process-global state that other modules' tests also touch.
+    fn with_env<R>(key: &str, value: Option<&str>, f: impl FnOnce() -> R) -> R {
+        let prev = std::env::var_os(key);
+        match value {
+            Some(v) => std::env::set_var(key, v),
+            None => std::env::remove_var(key),
+        }
+        let r = f();
+        match prev {
+            Some(v) => std::env::set_var(key, v),
+            None => std::env::remove_var(key),
+        }
+        r
+    }
+
+    #[test]
+    fn resolve_model_path_prefers_ggml_form() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("ggml-base.en.bin"), b"x").unwrap();
+        std::fs::write(tmp.path().join("base.en.bin"), b"x").unwrap();
+        let p = resolve_model_path(tmp.path(), "base.en").unwrap();
+        assert_eq!(p.file_name().unwrap(), "ggml-base.en.bin");
+    }
+
+    #[test]
+    fn resolve_model_path_falls_back_to_plain_form() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("base.en.bin"), b"x").unwrap();
+        let p = resolve_model_path(tmp.path(), "base.en").unwrap();
+        assert_eq!(p.file_name().unwrap(), "base.en.bin");
+    }
+
+    #[test]
+    fn resolve_model_path_accepts_full_filename() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("custom-name.bin"), b"x").unwrap();
+        let p = resolve_model_path(tmp.path(), "custom-name.bin").unwrap();
+        assert_eq!(p.file_name().unwrap(), "custom-name.bin");
+    }
+
+    #[test]
+    fn resolve_model_path_returns_none_when_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(resolve_model_path(tmp.path(), "nonexistent").is_none());
+    }
+
+    /// Build a fake whisper-cli binary inside `dir` and return its path.
+    /// On Unix it gets `0o755` so [`is_executable_file`] accepts it; on
+    /// other platforms its mere existence is enough.
+    fn fake_whisper_bin(dir: &Path) -> PathBuf {
+        let path = dir.join("whisper-cli");
+        std::fs::write(&path, b"#!/bin/sh\nexit 0\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        path
+    }
+
+    #[test]
+    fn resolve_uses_flag_over_env_for_model_name() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let model_dir = tempfile::tempdir().unwrap();
+        std::fs::write(model_dir.path().join("ggml-flag-wins.bin"), b"x").unwrap();
+        std::fs::write(model_dir.path().join("ggml-env-loses.bin"), b"x").unwrap();
+
+        let input = tempfile::NamedTempFile::new().unwrap();
+        let whisper_dir = tempfile::tempdir().unwrap();
+        let whisper_bin = fake_whisper_bin(whisper_dir.path());
+        let out_dir = tempfile::tempdir().unwrap();
+
+        let cfg = with_env(ENV_MODEL, Some("env-loses"), || {
+            with_env(
+                ENV_MODEL_PATH,
+                Some(model_dir.path().to_str().unwrap()),
+                || {
+                    with_env(ENV_WHISPER_BIN, Some(whisper_bin.to_str().unwrap()), || {
+                        Config::resolve(CliInputs {
+                            input: input.path().to_path_buf(),
+                            out_dir: out_dir.path().to_path_buf(),
+                            model: Some("flag-wins".to_string()),
+                            keep_temp: false,
+                        })
+                    })
+                },
+            )
+        })
+        .expect("config should resolve");
+
+        assert_eq!(cfg.model_name, "flag-wins");
+        assert_eq!(cfg.model_path.file_name().unwrap(), "ggml-flag-wins.bin");
+    }
+
+    #[test]
+    fn resolve_uses_env_when_no_flag() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let model_dir = tempfile::tempdir().unwrap();
+        std::fs::write(model_dir.path().join("ggml-env-name.bin"), b"x").unwrap();
+
+        let input = tempfile::NamedTempFile::new().unwrap();
+        let whisper_dir = tempfile::tempdir().unwrap();
+        let whisper_bin = fake_whisper_bin(whisper_dir.path());
+        let out_dir = tempfile::tempdir().unwrap();
+
+        let cfg = with_env(ENV_MODEL, Some("env-name"), || {
+            with_env(
+                ENV_MODEL_PATH,
+                Some(model_dir.path().to_str().unwrap()),
+                || {
+                    with_env(ENV_WHISPER_BIN, Some(whisper_bin.to_str().unwrap()), || {
+                        Config::resolve(CliInputs {
+                            input: input.path().to_path_buf(),
+                            out_dir: out_dir.path().to_path_buf(),
+                            model: None,
+                            keep_temp: false,
+                        })
+                    })
+                },
+            )
+        })
+        .expect("config should resolve");
+
+        assert_eq!(cfg.model_name, "env-name");
+    }
+
+    #[test]
+    fn resolve_falls_back_to_default_model_name() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let model_dir = tempfile::tempdir().unwrap();
+        let bin_name = format!("ggml-{DEFAULT_MODEL_NAME}.bin");
+        std::fs::write(model_dir.path().join(&bin_name), b"x").unwrap();
+
+        let input = tempfile::NamedTempFile::new().unwrap();
+        let whisper_dir = tempfile::tempdir().unwrap();
+        let whisper_bin = fake_whisper_bin(whisper_dir.path());
+        let out_dir = tempfile::tempdir().unwrap();
+
+        let cfg = with_env(ENV_MODEL, None, || {
+            with_env(
+                ENV_MODEL_PATH,
+                Some(model_dir.path().to_str().unwrap()),
+                || {
+                    with_env(ENV_WHISPER_BIN, Some(whisper_bin.to_str().unwrap()), || {
+                        Config::resolve(CliInputs {
+                            input: input.path().to_path_buf(),
+                            out_dir: out_dir.path().to_path_buf(),
+                            model: None,
+                            keep_temp: false,
+                        })
+                    })
+                },
+            )
+        })
+        .expect("config should resolve with default model");
+
+        assert_eq!(cfg.model_name, DEFAULT_MODEL_NAME);
+    }
+
+    #[test]
+    fn resolve_creates_missing_out_dir() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let model_dir = tempfile::tempdir().unwrap();
+        let bin_name = format!("ggml-{DEFAULT_MODEL_NAME}.bin");
+        std::fs::write(model_dir.path().join(&bin_name), b"x").unwrap();
+
+        let input = tempfile::NamedTempFile::new().unwrap();
+        let whisper_dir = tempfile::tempdir().unwrap();
+        let whisper_bin = fake_whisper_bin(whisper_dir.path());
+
+        let parent = tempfile::tempdir().unwrap();
+        let out_dir = parent.path().join("nested/created/by/resolve");
+        assert!(!out_dir.exists());
+
+        let cfg = with_env(
+            ENV_MODEL_PATH,
+            Some(model_dir.path().to_str().unwrap()),
+            || {
+                with_env(ENV_WHISPER_BIN, Some(whisper_bin.to_str().unwrap()), || {
+                    // Also clear ENV_MODEL so this test isn't sensitive to
+                    // whatever the surrounding shell sets.
+                    with_env(ENV_MODEL, None, || {
+                        Config::resolve(CliInputs {
+                            input: input.path().to_path_buf(),
+                            out_dir: out_dir.clone(),
+                            model: None,
+                            keep_temp: false,
+                        })
+                    })
+                })
+            },
+        )
+        .expect("config should create missing out-dir");
+
+        assert!(cfg.out_dir.is_dir());
+    }
+
+    #[test]
+    fn resolve_errors_on_missing_input() {
+        let cfg = Config::resolve(CliInputs {
+            input: PathBuf::from("/definitely/does/not/exist/scribe-test.wav"),
+            out_dir: PathBuf::from("/tmp"),
+            model: None,
+            keep_temp: false,
+        });
+        assert!(cfg.is_err());
+    }
+
+    // Reference doctor::resolve_whisper_bin from inside tests so we know
+    // the env-var precedence path we depend on stays functional.
+    #[test]
+    fn doctor_resolve_whisper_bin_is_reachable() {
+        let _ = crate::doctor::resolve_whisper_bin();
+    }
+}

--- a/crates/scribe/src/doctor.rs
+++ b/crates/scribe/src/doctor.rs
@@ -230,6 +230,9 @@ mod tests {
 
     #[test]
     fn resolve_whisper_bin_prefers_env() {
+        let _g = crate::which::ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let key = ENV_WHISPER_BIN;
         let prev = std::env::var_os(key);
         std::env::set_var(key, "/custom/whisper-cli");
@@ -244,6 +247,9 @@ mod tests {
 
     #[test]
     fn resolve_whisper_bin_uses_default() {
+        let _g = crate::which::ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let key = ENV_WHISPER_BIN;
         let prev = std::env::var_os(key);
         std::env::remove_var(key);
@@ -259,6 +265,9 @@ mod tests {
 
     #[test]
     fn resolve_model_dir_prefers_env() {
+        let _g = crate::which::ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let key = ENV_MODEL_PATH;
         let prev = std::env::var_os(key);
         std::env::set_var(key, "/custom/models");
@@ -272,6 +281,9 @@ mod tests {
 
     #[test]
     fn resolve_model_dir_uses_default() {
+        let _g = crate::which::ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let key = ENV_MODEL_PATH;
         let prev = std::env::var_os(key);
         std::env::remove_var(key);

--- a/crates/scribe/src/ffmpeg.rs
+++ b/crates/scribe/src/ffmpeg.rs
@@ -1,0 +1,94 @@
+//! Subprocess wrappers around `ffmpeg` and `ffprobe`.
+//!
+//! Two operations:
+//!
+//! - [`probe_duration_sec`] runs `ffprobe` to get the audio/video duration
+//!   in seconds, used to populate the `duration_sec:` frontmatter field.
+//! - [`resample_to_wav`] runs `ffmpeg` to resample the input to the
+//!   16 kHz mono PCM s16le WAV that whisper.cpp expects.
+//!
+//! Both commands write to caller-supplied paths so the orchestrator owns
+//! tempfile lifetime (and `--keep-temp` semantics).
+
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use anyhow::{anyhow, Context, Result};
+use tracing::debug;
+
+use crate::which::which_on_path;
+
+/// Run `ffprobe -v error -show_entries format=duration -of
+/// default=nw=1:nokey=1 <input>` and parse the result as seconds.
+///
+/// Returns an error if `ffprobe` is not on `PATH`, fails to spawn,
+/// exits non-zero, or prints something we can't parse as `f64`.
+pub fn probe_duration_sec(input: &Path) -> Result<f64> {
+    let bin = which_on_path("ffprobe")
+        .ok_or_else(|| anyhow!("ffprobe not found on PATH (install ffmpeg)"))?;
+    let output = Command::new(&bin)
+        .args([
+            "-v",
+            "error",
+            "-show_entries",
+            "format=duration",
+            "-of",
+            "default=nw=1:nokey=1",
+        ])
+        .arg(input)
+        .stdin(Stdio::null())
+        .output()
+        .with_context(|| format!("failed to invoke ffprobe at {}", bin.display()))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(anyhow!(
+            "ffprobe exited with status {}: {}",
+            output.status,
+            stderr.trim()
+        ));
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let trimmed = stdout.trim();
+    trimmed
+        .parse::<f64>()
+        .with_context(|| format!("ffprobe returned unparseable duration: {trimmed:?}"))
+}
+
+/// Run `ffmpeg -y -i <input> -ar 16000 -ac 1 -c:a pcm_s16le <out>`.
+///
+/// `-y` forces overwrite — we expect `out` to be a freshly-created
+/// tempfile that the caller already owns. ffmpeg's stderr is captured and
+/// surfaced on failure so the user sees the actual decoder error rather
+/// than a bare exit code.
+pub fn resample_to_wav(input: &Path, out: &Path) -> Result<()> {
+    let bin = which_on_path("ffmpeg")
+        .ok_or_else(|| anyhow!("ffmpeg not found on PATH (see docs/06-troubleshooting.md)"))?;
+    debug!(
+        "ffmpeg: resampling {} → {} (16 kHz mono PCM s16le)",
+        input.display(),
+        out.display()
+    );
+    let output = Command::new(&bin)
+        .arg("-y")
+        .arg("-i")
+        .arg(input)
+        .args(["-ar", "16000", "-ac", "1", "-c:a", "pcm_s16le"])
+        .arg(out)
+        // ffmpeg is chatty on stderr even when it succeeds; suppress its
+        // banner from the user's terminal but capture for error context.
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .output()
+        .with_context(|| format!("failed to invoke ffmpeg at {}", bin.display()))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(anyhow!(
+            "ffmpeg failed (status {}) while resampling {}:\n{}",
+            output.status,
+            input.display(),
+            stderr.trim()
+        ));
+    }
+    Ok(())
+}

--- a/crates/scribe/src/main.rs
+++ b/crates/scribe/src/main.rs
@@ -1,8 +1,9 @@
 //! Scribe CLI entry point.
 //!
 //! Top-level clap-derived CLI with `transcribe` and `doctor` subcommands.
-//! `doctor` is fully wired (issue #5); `transcribe` is still the v0.1
-//! stub awaiting issue #6.
+//! Both are now fully wired: `doctor` (issue #5) verifies the runtime,
+//! `transcribe` (issue #6) runs the ffmpeg → whisper.cpp → markdown +
+//! JSON pipeline.
 
 use std::path::PathBuf;
 use std::process::ExitCode;
@@ -11,8 +12,13 @@ use anyhow::Result;
 use clap::{Parser, Subcommand};
 use tracing_subscriber::EnvFilter;
 
+mod config;
 mod doctor;
+mod ffmpeg;
+mod output;
+mod pipeline;
 mod which;
+mod whisper;
 
 /// Verbatim audio-to-Markdown transcription CLI.
 ///
@@ -47,6 +53,10 @@ struct TranscribeArgs {
     /// Optional whisper.cpp model name (e.g. `large-v3`).
     #[arg(long, value_name = "NAME")]
     model: Option<String>,
+
+    /// Preserve the intermediate 16 kHz WAV. Useful for debugging.
+    #[arg(long)]
+    keep_temp: bool,
 }
 
 fn main() -> ExitCode {
@@ -82,8 +92,15 @@ fn init_tracing() {
         .init();
 }
 
-fn run_transcribe(_args: TranscribeArgs) -> Result<()> {
-    println!("scribe transcribe: not implemented");
+fn run_transcribe(args: TranscribeArgs) -> Result<()> {
+    let cli = config::CliInputs {
+        input: args.input,
+        out_dir: args.out_dir,
+        model: args.model,
+        keep_temp: args.keep_temp,
+    };
+    let md_path = pipeline::run(cli)?;
+    println!("{}", md_path.display());
     Ok(())
 }
 

--- a/crates/scribe/src/output.rs
+++ b/crates/scribe/src/output.rs
@@ -1,0 +1,244 @@
+//! Filename slug, YAML frontmatter, and final markdown writing.
+//!
+//! All the *naming* logic lives here so the pipeline orchestrator doesn't
+//! have to. Two responsibilities:
+//!
+//! 1. Turn an input filename + a UTC instant into a stable basename of the
+//!    form `<slug>-<YYYYMMDD-HHMMSS>` that both the markdown and the JSON
+//!    sidecar share.
+//! 2. Wrap the verbatim text whisper-cli emitted in YAML frontmatter and
+//!    write the resulting `.md`. The text body is byte-for-byte the same
+//!    as the input — no whitespace munging, no rewriting.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, SecondsFormat, Utc};
+
+/// Metadata captured before whisper-cli runs, threaded through to the
+/// frontmatter writer.
+///
+/// Kept separate from `Config` so frontmatter assembly is unit-testable
+/// without spinning up a real pipeline.
+#[derive(Debug, Clone)]
+pub struct FrontmatterMeta<'a> {
+    /// Absolute path of the original `--input` file, written verbatim into
+    /// the `source:` field.
+    pub source: &'a Path,
+    /// Display title — currently just the input filename stem.
+    pub title: &'a str,
+    /// Capture instant; serialized as ISO-8601 in UTC with second precision.
+    pub created: DateTime<Utc>,
+    /// Source file duration in seconds, from `ffprobe`.
+    pub duration_sec: f64,
+    /// Logical model name (e.g. `base.en`).
+    pub model: &'a str,
+    /// Filename of the JSON sidecar, *not* a path — relative to the same
+    /// directory as the markdown.
+    pub sidecar_filename: &'a str,
+}
+
+/// Lower-case ASCII alphanumerics; everything else collapses to a single `-`.
+/// Leading/trailing dashes are trimmed. Empty input → `"untitled"`.
+///
+/// Examples:
+/// - `"My Podcast Ep 42"` → `"my-podcast-ep-42"`
+/// - `"jfk.wav"` (stem `"jfk"`) → `"jfk"`
+/// - `"   "` → `"untitled"`
+/// - `"日本語"` → `"untitled"` (no ASCII alphanumerics survive)
+pub fn slugify(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut last_dash = true; // suppress leading dashes
+    for c in input.chars() {
+        if c.is_ascii_alphanumeric() {
+            out.push(c.to_ascii_lowercase());
+            last_dash = false;
+        } else if !last_dash {
+            out.push('-');
+            last_dash = true;
+        }
+    }
+    // Trim trailing dash.
+    while out.ends_with('-') {
+        out.pop();
+    }
+    if out.is_empty() {
+        "untitled".to_string()
+    } else {
+        out
+    }
+}
+
+/// Format a UTC instant as `YYYYMMDD-HHMMSS` for use in transcript filenames.
+pub fn timestamp_for_filename(now: DateTime<Utc>) -> String {
+    now.format("%Y%m%d-%H%M%S").to_string()
+}
+
+/// Compute the shared basename for the `.md` and `.json` outputs.
+///
+/// `input_stem` is the filename without extension, as you'd get from
+/// `Path::file_stem`. `now` is the capture time — usually `Utc::now()`,
+/// but injectable for deterministic tests.
+pub fn basename(input_stem: &str, now: DateTime<Utc>) -> String {
+    format!("{}-{}", slugify(input_stem), timestamp_for_filename(now))
+}
+
+/// Render the YAML frontmatter block exactly as specified in issue #6 +
+/// `docs/04-cli-reference.md`.
+///
+/// The block is bracketed by `---\n` lines and ends with a blank line so
+/// the body that follows starts on a new paragraph. The `created` field is
+/// ISO 8601 in UTC with second precision (e.g. `2026-04-28T14:30:00Z`).
+/// `duration_sec` is rendered with one decimal place to match the docs
+/// example.
+pub fn render_frontmatter(meta: &FrontmatterMeta<'_>) -> String {
+    let created = meta.created.to_rfc3339_opts(SecondsFormat::Secs, true);
+    format!(
+        "---\n\
+         type: transcript\n\
+         source: {source}\n\
+         title: {title}\n\
+         created: {created}\n\
+         duration_sec: {duration:.1}\n\
+         model: {model}\n\
+         sidecar: {sidecar}\n\
+         tags: [type/transcript]\n\
+         ---\n\n",
+        source = meta.source.display(),
+        title = meta.title,
+        created = created,
+        duration = meta.duration_sec,
+        model = meta.model,
+        sidecar = meta.sidecar_filename,
+    )
+}
+
+/// Write `<out_dir>/<basename>.md` containing `frontmatter` followed by
+/// `body`. The body is written byte-for-byte; this function is the single
+/// gateway through which the verbatim contract is honored.
+pub fn write_markdown(
+    out_dir: &Path,
+    basename: &str,
+    frontmatter: &str,
+    body: &str,
+) -> Result<PathBuf> {
+    let path = out_dir.join(format!("{basename}.md"));
+    let mut contents = String::with_capacity(frontmatter.len() + body.len());
+    contents.push_str(frontmatter);
+    contents.push_str(body);
+    fs::write(&path, contents)
+        .with_context(|| format!("failed to write markdown to {}", path.display()))?;
+    Ok(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    #[test]
+    fn slugify_basic() {
+        assert_eq!(slugify("My Podcast Ep 42"), "my-podcast-ep-42");
+    }
+
+    #[test]
+    fn slugify_collapses_runs() {
+        assert_eq!(slugify("hello   world!!!foo"), "hello-world-foo");
+    }
+
+    #[test]
+    fn slugify_strips_edges() {
+        assert_eq!(slugify("---hello---"), "hello");
+        assert_eq!(slugify("!!!a!!!"), "a");
+    }
+
+    #[test]
+    fn slugify_lowercases() {
+        assert_eq!(slugify("CamelCase"), "camelcase");
+    }
+
+    #[test]
+    fn slugify_keeps_digits() {
+        assert_eq!(slugify("Episode 007"), "episode-007");
+    }
+
+    #[test]
+    fn slugify_empty_becomes_untitled() {
+        assert_eq!(slugify(""), "untitled");
+        assert_eq!(slugify("   "), "untitled");
+        assert_eq!(slugify("---"), "untitled");
+    }
+
+    #[test]
+    fn slugify_drops_non_ascii() {
+        // Spec says non-alphanumerics → '-'. We treat non-ASCII as
+        // non-alphanumeric so the slug stays URL-safe.
+        assert_eq!(slugify("日本語"), "untitled");
+        assert_eq!(slugify("café-au-lait"), "caf-au-lait");
+    }
+
+    #[test]
+    fn timestamp_format_is_compact() {
+        let t = Utc.with_ymd_and_hms(2026, 4, 28, 14, 30, 0).unwrap();
+        assert_eq!(timestamp_for_filename(t), "20260428-143000");
+    }
+
+    #[test]
+    fn basename_combines_slug_and_ts() {
+        let t = Utc.with_ymd_and_hms(2026, 4, 28, 14, 30, 0).unwrap();
+        assert_eq!(
+            basename("My Podcast Ep 42", t),
+            "my-podcast-ep-42-20260428-143000"
+        );
+    }
+
+    #[test]
+    fn frontmatter_matches_spec() {
+        let t = Utc.with_ymd_and_hms(2026, 4, 28, 14, 30, 0).unwrap();
+        let meta = FrontmatterMeta {
+            source: Path::new("/abs/path/to/My Podcast Ep 42.mp3"),
+            title: "My Podcast Ep 42",
+            created: t,
+            duration_sec: 3127.4,
+            model: "large-v3",
+            sidecar_filename: "my-podcast-ep-42-20260428-143000.json",
+        };
+        let got = render_frontmatter(&meta);
+        let expected = "---\n\
+                        type: transcript\n\
+                        source: /abs/path/to/My Podcast Ep 42.mp3\n\
+                        title: My Podcast Ep 42\n\
+                        created: 2026-04-28T14:30:00Z\n\
+                        duration_sec: 3127.4\n\
+                        model: large-v3\n\
+                        sidecar: my-podcast-ep-42-20260428-143000.json\n\
+                        tags: [type/transcript]\n\
+                        ---\n\n";
+        assert_eq!(got, expected);
+    }
+
+    #[test]
+    fn frontmatter_renders_integer_duration_with_one_decimal() {
+        let t = Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap();
+        let meta = FrontmatterMeta {
+            source: Path::new("/x.mp3"),
+            title: "x",
+            created: t,
+            duration_sec: 11.0,
+            model: "base.en",
+            sidecar_filename: "x-20260101-000000.json",
+        };
+        let got = render_frontmatter(&meta);
+        assert!(got.contains("duration_sec: 11.0\n"));
+    }
+
+    #[test]
+    fn write_markdown_preserves_body_verbatim() {
+        let tmp = tempfile::tempdir().unwrap();
+        let body = " leading space and\n trailing newline preserved \n";
+        let path = write_markdown(tmp.path(), "x-1", "---\nhdr\n---\n\n", body).unwrap();
+        let contents = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(contents, format!("---\nhdr\n---\n\n{body}"));
+    }
+}

--- a/crates/scribe/src/pipeline.rs
+++ b/crates/scribe/src/pipeline.rs
@@ -1,0 +1,138 @@
+//! End-to-end orchestration of `scribe transcribe`.
+//!
+//! Composes [`crate::config`], [`crate::ffmpeg`], [`crate::whisper`], and
+//! [`crate::output`] into the single function [`run`] that `main` calls.
+//!
+//! The order:
+//!
+//! 1. Resolve the [`Config`] from CLI flags + env.
+//! 2. ffprobe for duration (so we have it for the frontmatter).
+//! 3. ffmpeg resample to a temp 16 kHz mono PCM WAV.
+//! 4. whisper-cli on that WAV, writing `.txt` + `.json` directly into
+//!    `--out-dir`.
+//! 5. Read the `.txt`, wrap in YAML frontmatter, write `.md`.
+//! 6. Delete the `.txt` (markdown is canonical), drop the temp WAV
+//!    unless `--keep-temp`.
+//! 7. Print the final `.md` path on stdout.
+
+use std::fs;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+use tempfile::Builder as TempBuilder;
+use tracing::info;
+
+use crate::config::{CliInputs, Config};
+use crate::ffmpeg;
+use crate::output::{self, FrontmatterMeta};
+use crate::whisper;
+
+/// Run the full pipeline for one input file. Returns the absolute path of
+/// the markdown that was written.
+pub fn run(cli: CliInputs) -> Result<PathBuf> {
+    let cfg = Config::resolve(cli)?;
+    info!(
+        "transcribe: input={} model={} out_dir={}",
+        cfg.input.display(),
+        cfg.model_name,
+        cfg.out_dir.display()
+    );
+
+    // Capture the timestamp once so the slug, the basename, and the
+    // frontmatter `created` field all line up.
+    let now = Utc::now();
+    let stem = cfg
+        .input
+        .file_stem()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "untitled".to_string());
+    let basename = output::basename(&stem, now);
+
+    // 1. ffprobe for duration — non-fatal in the sense that a `.wav` whose
+    //    container reports nothing useful shouldn't kill the whole run,
+    //    but we surface the failure as a 0.0 with a warning rather than
+    //    swallowing it silently. (Spec says read from ffprobe; we comply
+    //    when ffprobe answers, log and continue otherwise.)
+    let duration_sec = match ffmpeg::probe_duration_sec(&cfg.input) {
+        Ok(d) => d,
+        Err(e) => {
+            tracing::warn!(
+                "ffprobe could not determine duration for {}: {:#} (continuing with 0.0)",
+                cfg.input.display(),
+                e
+            );
+            0.0
+        }
+    };
+
+    // 2. ffmpeg → temp WAV. tempfile gives us automatic cleanup; if
+    //    --keep-temp is set we call `into_temp_path().keep()` to detach
+    //    it from the Drop guard.
+    let temp_wav = TempBuilder::new()
+        .prefix("scribe-")
+        .suffix(".wav")
+        .tempfile()
+        .context("failed to create temp WAV file")?;
+    let temp_wav_path = temp_wav.path().to_path_buf();
+    ffmpeg::resample_to_wav(&cfg.input, &temp_wav_path)?;
+
+    // 3. whisper-cli — writes `<out_dir>/<basename>.{txt,json}`.
+    let out_prefix = cfg.out_dir.join(&basename);
+    let artifacts = whisper::transcribe(
+        &cfg.whisper_bin,
+        &cfg.model_path,
+        &temp_wav_path,
+        &out_prefix,
+    )?;
+
+    // 4. Read whisper's verbatim text. Anything that mutates `body` here
+    //    is a verbatim-contract bug — see docs/01-architecture.md.
+    let body = fs::read_to_string(&artifacts.txt).with_context(|| {
+        format!(
+            "failed to read whisper text output at {}",
+            artifacts.txt.display()
+        )
+    })?;
+
+    // 5. Frontmatter + write markdown.
+    let sidecar_filename = artifacts
+        .json
+        .file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| format!("{basename}.json"));
+    let meta = FrontmatterMeta {
+        source: &cfg.input,
+        title: &stem,
+        created: now,
+        duration_sec,
+        model: &cfg.model_name,
+        sidecar_filename: &sidecar_filename,
+    };
+    let frontmatter = output::render_frontmatter(&meta);
+    let md_path = output::write_markdown(&cfg.out_dir, &basename, &frontmatter, &body)?;
+
+    // 6. Delete the .txt (markdown is canonical). The .json stays put.
+    if let Err(e) = fs::remove_file(&artifacts.txt) {
+        tracing::warn!(
+            "failed to remove intermediate text file at {}: {}",
+            artifacts.txt.display(),
+            e
+        );
+    }
+
+    // 7. Honor --keep-temp.
+    if cfg.keep_temp {
+        // Persist the tempfile beyond the Drop guard. We can't use
+        // `into_temp_path().keep()` directly because we still hold
+        // `temp_wav` by value; closing it that way is the right shape.
+        let kept = temp_wav.into_temp_path();
+        let kept_path = kept.to_path_buf();
+        kept.keep()
+            .with_context(|| format!("failed to retain temp WAV at {}", kept_path.display()))?;
+        tracing::info!("--keep-temp: temp WAV preserved at {}", kept_path.display());
+    }
+    // Otherwise: `temp_wav` drops at end of scope and is unlinked.
+
+    Ok(md_path)
+}

--- a/crates/scribe/src/which.rs
+++ b/crates/scribe/src/which.rs
@@ -45,11 +45,9 @@ pub fn which_on_path(name: &str) -> Option<PathBuf> {
 /// The returned path is *not* validated — callers should follow up with
 /// [`is_executable_file`] (or run the binary) to confirm it actually works.
 ///
-/// Currently unused by `doctor` (which needs to combine env-var lookup with
-/// `dirs::home_dir()` and so handles its own resolution), but kept here for
-/// the `transcribe` pipeline (issue #6), which will resolve absolute paths
-/// to ffmpeg / whisper-cli the same way.
-#[allow(dead_code)]
+/// Used by [`crate::config`] to resolve the `whisper-cli` binary path
+/// when neither `$SCRIBE_WHISPER_BIN` is set nor the `doctor` resolution
+/// path is reused directly.
 pub fn env_or_default<P: Into<PathBuf>>(env_var: &str, default: P) -> PathBuf {
     match std::env::var_os(env_var) {
         Some(v) if !v.is_empty() => PathBuf::from(v),
@@ -105,14 +103,25 @@ fn first_nonempty_line(buf: &[u8]) -> Option<String> {
         .map(|s| s.to_string())
 }
 
+/// Process-wide mutex for test code that mutates the environment.
+///
+/// `cargo test` runs tests in parallel by default. Any test that calls
+/// `std::env::set_var` or `remove_var` for one of the `SCRIBE_*` keys
+/// must hold this lock for the duration of the read so a sibling test
+/// doesn't yank the value out from under it.
+///
+/// This is `#[cfg(test)]` only — there's no reason production code would
+/// need to serialize env access.
+#[cfg(test)]
+pub static ENV_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn env_or_default_prefers_env() {
-        // SAFETY: tests are single-threaded for env access by default; if we
-        // ever flip to multi-threaded test runners, swap this for a serial_test.
+        let _g = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let key = "SCRIBE_TEST_ENV_OR_DEFAULT_PREFERS_ENV";
         std::env::set_var(key, "/tmp/from-env");
         let p = env_or_default(key, "/tmp/default");
@@ -122,6 +131,7 @@ mod tests {
 
     #[test]
     fn env_or_default_falls_back_when_unset() {
+        let _g = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let key = "SCRIBE_TEST_ENV_OR_DEFAULT_FALLS_BACK_WHEN_UNSET";
         std::env::remove_var(key);
         let p = env_or_default(key, "/tmp/default");
@@ -130,6 +140,7 @@ mod tests {
 
     #[test]
     fn env_or_default_falls_back_when_empty() {
+        let _g = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let key = "SCRIBE_TEST_ENV_OR_DEFAULT_FALLS_BACK_WHEN_EMPTY";
         std::env::set_var(key, "");
         let p = env_or_default(key, "/tmp/default");

--- a/crates/scribe/src/whisper.rs
+++ b/crates/scribe/src/whisper.rs
@@ -1,0 +1,120 @@
+//! Subprocess wrapper around `whisper-cli` (whisper.cpp).
+//!
+//! The single entry point [`transcribe`] runs:
+//!
+//! ```text
+//! <whisper-bin> -m <model> -f <wav> -of <out-prefix> -otxt -ojf
+//! ```
+//!
+//! and on success returns the absolute paths of the two artifacts whisper
+//! wrote: `<out-prefix>.txt` (verbatim text) and `<out-prefix>.json`
+//! (segment-level JSON). The orchestrator is responsible for transforming
+//! the `.txt` into the final `.md` and for the `.json` sidecar's final
+//! placement (it's already where it needs to be).
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use anyhow::{anyhow, Context, Result};
+use tracing::debug;
+
+/// Paths to the artifacts whisper-cli wrote, given an `-of <prefix>` flag.
+#[derive(Debug, Clone)]
+pub struct WhisperArtifacts {
+    pub txt: PathBuf,
+    pub json: PathBuf,
+}
+
+/// Run whisper-cli end-to-end.
+///
+/// `out_prefix` is passed as the `-of` flag value; whisper appends
+/// `.txt` and `.json` to it. The prefix should be `<out_dir>/<basename>`
+/// so the artifacts land directly in the user's output directory.
+///
+/// stderr is captured and surfaced on failure. stdout is suppressed —
+/// whisper.cpp prints the transcript to stdout by default *in addition*
+/// to the `-of` files, and we don't want that noise in the user's
+/// terminal.
+pub fn transcribe(
+    whisper_bin: &Path,
+    model: &Path,
+    wav: &Path,
+    out_prefix: &Path,
+) -> Result<WhisperArtifacts> {
+    debug!(
+        "whisper-cli: transcribing {} with model {} → {}.{{txt,json}}",
+        wav.display(),
+        model.display(),
+        out_prefix.display()
+    );
+    let output = Command::new(whisper_bin)
+        .arg("-m")
+        .arg(model)
+        .arg("-f")
+        .arg(wav)
+        .arg("-of")
+        .arg(out_prefix)
+        .args(["-otxt", "-ojf"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .output()
+        .with_context(|| format!("failed to invoke whisper-cli at {}", whisper_bin.display()))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(anyhow!(
+            "whisper-cli failed (status {}) on {}:\n{}",
+            output.status,
+            wav.display(),
+            stderr.trim()
+        ));
+    }
+    let txt = with_extension(out_prefix, "txt");
+    let json = with_extension(out_prefix, "json");
+    if !txt.is_file() {
+        return Err(anyhow!(
+            "whisper-cli did not produce expected text output at {}",
+            txt.display()
+        ));
+    }
+    if !json.is_file() {
+        return Err(anyhow!(
+            "whisper-cli did not produce expected JSON output at {}",
+            json.display()
+        ));
+    }
+    Ok(WhisperArtifacts { txt, json })
+}
+
+/// Append a literal extension to `prefix` without replacing whatever the
+/// path already ends with. We can't use `Path::with_extension` because the
+/// prefix already includes a timestamp (`...-20260428-143000`) that
+/// `with_extension` would treat as the existing extension and clobber.
+fn with_extension(prefix: &Path, ext: &str) -> PathBuf {
+    let mut s = prefix.as_os_str().to_owned();
+    s.push(".");
+    s.push(ext);
+    PathBuf::from(s)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn with_extension_preserves_dotted_prefix() {
+        let p = with_extension(Path::new("/tmp/my-podcast-ep-42-20260428-143000"), "txt");
+        assert_eq!(
+            p,
+            PathBuf::from("/tmp/my-podcast-ep-42-20260428-143000.txt")
+        );
+    }
+
+    #[test]
+    fn with_extension_does_not_strip_dotted_segment() {
+        // A naive `Path::with_extension` would turn this into `.txt`,
+        // dropping the `143000` suffix. Confirm we don't.
+        let p = with_extension(Path::new("/tmp/file.with.dots"), "txt");
+        assert_eq!(p, PathBuf::from("/tmp/file.with.dots.txt"));
+    }
+}


### PR DESCRIPTION
Closes #6.

Implements the core `scribe transcribe` pipeline end-to-end. Modules per the issue: `pipeline.rs` (orchestrator), `ffmpeg.rs` (ffmpeg + ffprobe wrappers), `whisper.rs` (whisper-cli wrapper), `output.rs` (slug + frontmatter + markdown writer), `config.rs` (CLI/env resolution). Reuses `which.rs` helpers and removes the `#[allow(dead_code)]` from `env_or_default`.

## Behavior

- Resolves config: flag values override `SCRIBE_MODEL` / `SCRIBE_MODEL_PATH` / `SCRIBE_WHISPER_BIN`; model name falls back to `base.en`.
- ffprobe → duration; ffmpeg → temp 16 kHz mono PCM s16le WAV (via `tempfile`, honors `--keep-temp`); whisper-cli with `-otxt -ojf` → `<out_dir>/<basename>.{txt,json}`.
- Wraps the verbatim text in YAML frontmatter (template per spec) → `<basename>.md`. Deletes the intermediate `.txt`. Leaves the `.json` sidecar in place. Prints the `.md` path on stdout.
- `<basename>` = `<slug>-<YYYYMMDD-HHMMSS>` (UTC); slug is lowercased ASCII-alphanumerics with everything else collapsed to `-`.

## Verbatim contract

Markdown body is byte-for-byte what whisper-cli wrote. No LLM, no rewriting, no whitespace munging. Honored — see the smoke output below.

## Tests

44 unit tests pass:

- `output::tests` — slug edge cases (empty, non-ASCII, runs, edges, casing, digits), timestamp format, basename, frontmatter against the spec example, body verbatim through `write_markdown`.
- `config::tests` — model-name precedence (flag > env > default), out-dir auto-creation, model `.bin` resolution forms, missing-input error.
- A process-wide `ENV_TEST_LOCK` in `which.rs` serializes env-touching tests in `config` + `doctor` so cargo's parallel runner doesn't yank vars out from under each other.

`cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all` all green.

Subprocess invocations are not unit-tested; integration tests against fixture audio land in #7.

## Smoke test

```sh
./target/debug/scribe transcribe \
    --input ~/raibid-labs/voice-stuff/third_party/whisper.cpp/samples/jfk.wav \
    --out-dir /tmp/scribe-smoke
```

stdout (the `.md` path):

```
/tmp/scribe-smoke/jfk-20260501-193744.md
```

`/tmp/scribe-smoke/jfk-20260501-193744.md`:

```
---
type: transcript
source: /home/beengud/raibid-labs/voice-stuff/third_party/whisper.cpp/samples/jfk.wav
title: jfk
created: 2026-05-01T19:37:44Z
duration_sec: 11.0
model: base.en
sidecar: jfk-20260501-193744.json
tags: [type/transcript]
---

 And so my fellow Americans, ask not what your country can do for you, ask what you can do for your country.
```

YAML frontmatter parses cleanly via `python3 -c "import yaml; ..."`. JSON sidecar parses via `jq` and contains segment `text` plus per-token `timestamps` (`from`/`to` as both `HH:MM:SS,ms` strings and millisecond `offsets`). The intermediate `.txt` is deleted; only `.md` + `.json` remain in `--out-dir`. `--keep-temp` preserves the temp WAV (logged as `--keep-temp: temp WAV preserved at /tmp/scribe-XXXX.wav`).

## Out of scope (per spec / roadmap)

URL inputs, yt-dlp, RSS, batch, watchfolder, diarization, alternative output formats — none touched.

## Files

- New: `crates/scribe/src/{pipeline,ffmpeg,whisper,output,config}.rs`
- Modified: `Cargo.toml` (`tempfile`, `chrono` workspace deps), `crates/scribe/Cargo.toml`, `crates/scribe/src/main.rs` (wiring), `crates/scribe/src/which.rs` (drop `dead_code` suppression, add test-only `ENV_TEST_LOCK`), `crates/scribe/src/doctor.rs` (use shared lock in tests).