### PR TITLE
chore: gitignore .claude/ agent worktree dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ logs/
 # Runtime
 *.sock
 *.pid
+
+# Claude Code agent worktrees
+.claude/


### PR DESCRIPTION
Tiny follow-up cleanup. The Agent tool's worktree-isolation mode leaves directories under `.claude/worktrees/` in the canonical checkout. They're harmless but noisy in `git status`.